### PR TITLE
TreeAnalyzer: implement partition asymmetry

### DIFF
--- a/src/main/java/sc/fiji/snt/analysis/MultiTreeStatistics.java
+++ b/src/main/java/sc/fiji/snt/analysis/MultiTreeStatistics.java
@@ -102,6 +102,9 @@ public class MultiTreeStatistics extends TreeStatistics {
 
 	/** Flag specifying {@value #AVG_REMOTE_ANGLE} statistics */
 	public static final String AVG_REMOTE_ANGLE = "Average remote bif. angle";
+	
+	/** Flag specifying {@value #AVG_PARTITION_ASYMMETRY} statistics */
+	public static final String AVG_PARTITION_ASYMMETRY = "Average partition asymmetry";
 
 	/** Flag for {@value #N_PATHS} statistics */
 	public static final String N_PATHS = "No. of paths";
@@ -133,6 +136,7 @@ public class MultiTreeStatistics extends TreeStatistics {
 			AVG_CONTRACTION, //
 			AVG_FRAGMENTATION, //
 			AVG_REMOTE_ANGLE, //
+			AVG_PARTITION_ASYMMETRY, //
 			DEPTH, //
 			HEIGHT, //
 			HIGHEST_PATH_ORDER, //
@@ -330,6 +334,9 @@ public class MultiTreeStatistics extends TreeStatistics {
 			}
 			if (normGuess.indexOf("remote") != -1 || normGuess.indexOf("bif") != -1) {
 				return AVG_REMOTE_ANGLE;
+			}
+			if (normGuess.indexOf("partition") != -1 || normGuess.indexOf("asymmetry") != -1) {
+				return AVG_PARTITION_ASYMMETRY;
 			}
 		}
 		return "unknown";

--- a/src/main/java/sc/fiji/snt/analysis/TreeAnalyzer.java
+++ b/src/main/java/sc/fiji/snt/analysis/TreeAnalyzer.java
@@ -373,6 +373,13 @@ public class TreeAnalyzer extends ContextCommand {
 				SNTUtils.log("Error: " + ignored.getMessage());
 				return Double.NaN;
 			}
+		case MultiTreeStatistics.AVG_PARTITION_ASYMMETRY:
+			try {
+				return getAvgPartitionAsymmetry();
+			} catch (final IllegalArgumentException ignored) {
+				SNTUtils.log("Error: " + ignored.getMessage());
+				return Double.NaN;
+			}
 		case MultiTreeStatistics.DEPTH:
 			return getDepth();
 		case MultiTreeStatistics.HEIGHT:

--- a/src/main/java/sc/fiji/snt/analysis/TreeStatistics.java
+++ b/src/main/java/sc/fiji/snt/analysis/TreeStatistics.java
@@ -104,6 +104,9 @@ public class TreeStatistics extends TreeAnalyzer {
 
 	/** Flag for {@value #REMOTE_BIF_ANGLES} statistics. */
 	public static final String REMOTE_BIF_ANGLES = "Remote bif. angles";
+	
+	/** Flag for {@value #PARTITION_ASYMMETRY} statistics. */
+	public static final String PARTITION_ASYMMETRY = "Partition asymmetry";
 
 	/**
 	 * Flag for analysis of {@value #VALUES}, an optional numeric property that
@@ -120,6 +123,7 @@ public class TreeStatistics extends TreeAnalyzer {
 			BRANCH_LENGTH, //
 			CONTRACTION, //
 			REMOTE_BIF_ANGLES, //
+			PARTITION_ASYMMETRY, //
 			INTER_NODE_DISTANCE, //
 			INTER_NODE_DISTANCE_SQUARED, //
 			MEAN_RADIUS, //
@@ -332,6 +336,9 @@ public class TreeStatistics extends TreeAnalyzer {
 		if (normGuess.indexOf("remote") != -1 && normGuess.indexOf("angle") != -1) {
 			return REMOTE_BIF_ANGLES;
 		}
+		if (normGuess.indexOf("partition") != -1 && normGuess.indexOf("asymmetry") != -1) {
+			return PARTITION_ASYMMETRY;
+		}
 		if (normGuess.indexOf("length") != -1 || normGuess.indexOf("cable") != -1) {
 			if (normGuess.indexOf("term") != -1) {
 				return TERMINAL_LENGTH;
@@ -432,6 +439,15 @@ public class TreeStatistics extends TreeAnalyzer {
 			try {
 				for (final double angle : getRemoteBifAngles())
 					stat.addValue(angle);
+			} catch (final IllegalArgumentException ignored) {
+				SNTUtils.log("Error: " + ignored.getMessage());
+				stat.addValue(Double.NaN);
+			}
+			break;
+		case PARTITION_ASYMMETRY:
+			try {
+				for (final double asymmetry : getPartitionAsymmetry())
+					stat.addValue(asymmetry);
 			} catch (final IllegalArgumentException ignored) {
 				SNTUtils.log("Error: " + ignored.getMessage());
 				stat.addValue(Double.NaN);
@@ -609,7 +625,7 @@ public class TreeStatistics extends TreeAnalyzer {
 			somaCompartment = somaCompartment.getAncestor(depth - somaCompartment.getOntologyDepth());
 		hist.annotateCategory(somaCompartment.acronym(), "soma", "blue");
 		hist.show();
-		tStats.getHistogram("remote angles").show();
+		tStats.getHistogram("partition asymmetry").show();
 		NodeStatistics<?> nStats =new NodeStatistics<>(tStats.getTips());
 				hist = nStats.getAnnotatedHistogram(depth);
 				hist.annotate("No. of tips: " + tStats.getTips().size());

--- a/src/main/java/sc/fiji/snt/plugin/AnalyzerCmd.java
+++ b/src/main/java/sc/fiji/snt/plugin/AnalyzerCmd.java
@@ -98,6 +98,9 @@ public class AnalyzerCmd extends CommonDynamicCmd {
 
 	@Parameter(label = MultiTreeStatistics.AVG_REMOTE_ANGLE)
 	private boolean avgRemoteAngle;
+	
+	@Parameter(label = MultiTreeStatistics.AVG_PARTITION_ASYMMETRY)
+	private boolean avgPartitionAsymmetry;
 
 	@Parameter(label = MultiTreeStatistics.N_BRANCH_POINTS)
 	private boolean nBPs;
@@ -190,6 +193,7 @@ public class AnalyzerCmd extends CommonDynamicCmd {
 		avgContraction = enable;
 		avgFragmentation = enable;
 		avgRemoteAngle = enable;
+		avgPartitionAsymmetry = enable;
 		cableLength = enable;
 		depth = enable;
 		height = enable;
@@ -216,6 +220,7 @@ public class AnalyzerCmd extends CommonDynamicCmd {
 		if (avgContraction) metrics.add(MultiTreeStatistics.AVG_CONTRACTION);
 		if (avgFragmentation) metrics.add(MultiTreeStatistics.AVG_FRAGMENTATION);
 		if(avgRemoteAngle) metrics.add(MultiTreeStatistics.AVG_REMOTE_ANGLE);
+		if(avgPartitionAsymmetry) metrics.add(MultiTreeStatistics.AVG_PARTITION_ASYMMETRY);
 		if(cableLength) metrics.add(MultiTreeStatistics.LENGTH);
 		if(terminalLength) metrics.add(MultiTreeStatistics.TERMINAL_LENGTH);
 		if(primaryLength) metrics.add(MultiTreeStatistics.PRIMARY_LENGTH);

--- a/src/main/java/sc/fiji/snt/plugin/GroupAnalyzerCmd.java
+++ b/src/main/java/sc/fiji/snt/plugin/GroupAnalyzerCmd.java
@@ -109,6 +109,7 @@ public class GroupAnalyzerCmd extends CommonDynamicCmd {
 			MultiTreeStatistics.AVG_CONTRACTION,
 			MultiTreeStatistics.AVG_FRAGMENTATION,
 			MultiTreeStatistics.AVG_REMOTE_ANGLE,
+			MultiTreeStatistics.AVG_PARTITION_ASYMMETRY,
 			MultiTreeStatistics.N_BRANCH_POINTS,
 			MultiTreeStatistics.N_TIPS,
 			MultiTreeStatistics.N_BRANCHES,

--- a/src/test/java/sc/fiji/snt/TreeAnalyzerTest.java
+++ b/src/test/java/sc/fiji/snt/TreeAnalyzerTest.java
@@ -74,8 +74,12 @@ public class TreeAnalyzerTest {
 		assertTrue("Width = 116.0", analyzer.getWidth() == 116d);
 		assertTrue("Height = 145.0", analyzer.getHeight() == 145d);
 		assertTrue("Depth = 0.0", analyzer.getDepth() == 0d);
-		final double avgContraction=  analyzer.getAvgContraction();
+		final double avgContraction = analyzer.getAvgContraction();
 		assertEquals("Avg contraction", 0.9628, avgContraction, precision);
+		final double avgRemoteBifAngle = analyzer.getAvgRemoteBifAngle();
+		assertEquals("Avg remote bif angle", 41.3833, avgRemoteBifAngle, precision);
+		final double avgPartitionAsymmetry = analyzer.getAvgPartitionAsymmetry();
+		assertEquals("Avg partition asymmetry", 0.0, avgPartitionAsymmetry, precision);
 
 		// Scaling tests
 		for (double scaleFactor : new double[] { .25d, 1d, 2d}) {


### PR DESCRIPTION
I have implemented partition asymmetry as defined in [L-measure](http://cng.gmu.edu:8080/Lm/help/Partition_asymmetry.htm)

Also adds tests for both remote bifurcation angles and partition asymmetry to TreeAnalyzerTest, assuming that the averages for both serve as a good-enough proxy for the full lists.