### PR TITLE
TreeAnalyzer: implement fractal dimension

### DIFF
--- a/src/main/java/sc/fiji/snt/analysis/MultiTreeStatistics.java
+++ b/src/main/java/sc/fiji/snt/analysis/MultiTreeStatistics.java
@@ -105,6 +105,9 @@ public class MultiTreeStatistics extends TreeStatistics {
 	
 	/** Flag specifying {@value #AVG_PARTITION_ASYMMETRY} statistics */
 	public static final String AVG_PARTITION_ASYMMETRY = "Average partition asymmetry";
+	
+	/** Flag specifying {@value #AVG_FRACTAL_DIMENSION} statistics */
+	public static final String AVG_FRACTAL_DIMENSION = "Average fractal dimension";
 
 	/** Flag for {@value #N_PATHS} statistics */
 	public static final String N_PATHS = "No. of paths";
@@ -137,6 +140,7 @@ public class MultiTreeStatistics extends TreeStatistics {
 			AVG_FRAGMENTATION, //
 			AVG_REMOTE_ANGLE, //
 			AVG_PARTITION_ASYMMETRY, //
+			AVG_FRACTAL_DIMENSION, //
 			DEPTH, //
 			HEIGHT, //
 			HIGHEST_PATH_ORDER, //
@@ -337,6 +341,9 @@ public class MultiTreeStatistics extends TreeStatistics {
 			}
 			if (normGuess.indexOf("partition") != -1 || normGuess.indexOf("asymmetry") != -1) {
 				return AVG_PARTITION_ASYMMETRY;
+			}
+			if (normGuess.indexOf("fractal") != -1) {
+				return AVG_FRACTAL_DIMENSION;
 			}
 		}
 		return "unknown";

--- a/src/main/java/sc/fiji/snt/analysis/TreeAnalyzer.java
+++ b/src/main/java/sc/fiji/snt/analysis/TreeAnalyzer.java
@@ -1065,8 +1065,8 @@ public class TreeAnalyzer extends ContextCommand {
 			if (children.size() > 2) {
 				continue;
 			}
-			List<Integer> tipCounts = new ArrayList<Integer>();
-			for (SWCPoint child : children) {
+			final List<Integer> tipCounts = new ArrayList<Integer>();
+			for (final SWCPoint child : children) {
 				int count = 0;
 				final DepthFirstIterator<SWCPoint, SWCWeightedEdge> dfi = sGraph.getDepthFirstIterator(child);
 				while (dfi.hasNext()) {

--- a/src/main/java/sc/fiji/snt/analysis/TreeAnalyzer.java
+++ b/src/main/java/sc/fiji/snt/analysis/TreeAnalyzer.java
@@ -380,6 +380,13 @@ public class TreeAnalyzer extends ContextCommand {
 				SNTUtils.log("Error: " + ignored.getMessage());
 				return Double.NaN;
 			}
+		case MultiTreeStatistics.AVG_FRACTAL_DIMENSION:
+			try {
+				return getAvgFractalDimension();
+			} catch (final IllegalArgumentException ignored) {
+				SNTUtils.log("Error: " + ignored.getMessage());
+				return Double.NaN;
+			}
 		case MultiTreeStatistics.DEPTH:
 			return getDepth();
 		case MultiTreeStatistics.HEIGHT:

--- a/src/main/java/sc/fiji/snt/analysis/TreeStatistics.java
+++ b/src/main/java/sc/fiji/snt/analysis/TreeStatistics.java
@@ -107,6 +107,9 @@ public class TreeStatistics extends TreeAnalyzer {
 	
 	/** Flag for {@value #PARTITION_ASYMMETRY} statistics. */
 	public static final String PARTITION_ASYMMETRY = "Partition asymmetry";
+	
+	/** Flag for {@value #FRACTAL_DIMENSION} statistics. */
+	public static final String FRACTAL_DIMENSION = "Fractal dimension";
 
 	/**
 	 * Flag for analysis of {@value #VALUES}, an optional numeric property that
@@ -124,6 +127,7 @@ public class TreeStatistics extends TreeAnalyzer {
 			CONTRACTION, //
 			REMOTE_BIF_ANGLES, //
 			PARTITION_ASYMMETRY, //
+			FRACTAL_DIMENSION, //
 			INTER_NODE_DISTANCE, //
 			INTER_NODE_DISTANCE_SQUARED, //
 			MEAN_RADIUS, //
@@ -339,6 +343,9 @@ public class TreeStatistics extends TreeAnalyzer {
 		if (normGuess.indexOf("partition") != -1 && normGuess.indexOf("asymmetry") != -1) {
 			return PARTITION_ASYMMETRY;
 		}
+		if (normGuess.indexOf("fractal") != -1) {
+			return FRACTAL_DIMENSION;
+		}
 		if (normGuess.indexOf("length") != -1 || normGuess.indexOf("cable") != -1) {
 			if (normGuess.indexOf("term") != -1) {
 				return TERMINAL_LENGTH;
@@ -448,6 +455,15 @@ public class TreeStatistics extends TreeAnalyzer {
 			try {
 				for (final double asymmetry : getPartitionAsymmetry())
 					stat.addValue(asymmetry);
+			} catch (final IllegalArgumentException ignored) {
+				SNTUtils.log("Error: " + ignored.getMessage());
+				stat.addValue(Double.NaN);
+			}
+			break;
+		case FRACTAL_DIMENSION:
+			try {
+				for (final double fDim : getFractalDimension())
+					stat.addValue(fDim);
 			} catch (final IllegalArgumentException ignored) {
 				SNTUtils.log("Error: " + ignored.getMessage());
 				stat.addValue(Double.NaN);
@@ -625,7 +641,7 @@ public class TreeStatistics extends TreeAnalyzer {
 			somaCompartment = somaCompartment.getAncestor(depth - somaCompartment.getOntologyDepth());
 		hist.annotateCategory(somaCompartment.acronym(), "soma", "blue");
 		hist.show();
-		tStats.getHistogram("partition asymmetry").show();
+		tStats.getHistogram("fractal dimension").show();
 		NodeStatistics<?> nStats =new NodeStatistics<>(tStats.getTips());
 				hist = nStats.getAnnotatedHistogram(depth);
 				hist.annotate("No. of tips: " + tStats.getTips().size());

--- a/src/main/java/sc/fiji/snt/plugin/AnalyzerCmd.java
+++ b/src/main/java/sc/fiji/snt/plugin/AnalyzerCmd.java
@@ -101,6 +101,9 @@ public class AnalyzerCmd extends CommonDynamicCmd {
 	
 	@Parameter(label = MultiTreeStatistics.AVG_PARTITION_ASYMMETRY)
 	private boolean avgPartitionAsymmetry;
+	
+	@Parameter(label = MultiTreeStatistics.AVG_FRACTAL_DIMENSION)
+	private boolean avgFractalDimension;
 
 	@Parameter(label = MultiTreeStatistics.N_BRANCH_POINTS)
 	private boolean nBPs;
@@ -194,6 +197,7 @@ public class AnalyzerCmd extends CommonDynamicCmd {
 		avgFragmentation = enable;
 		avgRemoteAngle = enable;
 		avgPartitionAsymmetry = enable;
+		avgFractalDimension = enable;
 		cableLength = enable;
 		depth = enable;
 		height = enable;
@@ -221,6 +225,7 @@ public class AnalyzerCmd extends CommonDynamicCmd {
 		if (avgFragmentation) metrics.add(MultiTreeStatistics.AVG_FRAGMENTATION);
 		if(avgRemoteAngle) metrics.add(MultiTreeStatistics.AVG_REMOTE_ANGLE);
 		if(avgPartitionAsymmetry) metrics.add(MultiTreeStatistics.AVG_PARTITION_ASYMMETRY);
+		if(avgFractalDimension) metrics.add(MultiTreeStatistics.AVG_FRACTAL_DIMENSION);
 		if(cableLength) metrics.add(MultiTreeStatistics.LENGTH);
 		if(terminalLength) metrics.add(MultiTreeStatistics.TERMINAL_LENGTH);
 		if(primaryLength) metrics.add(MultiTreeStatistics.PRIMARY_LENGTH);

--- a/src/main/java/sc/fiji/snt/plugin/GroupAnalyzerCmd.java
+++ b/src/main/java/sc/fiji/snt/plugin/GroupAnalyzerCmd.java
@@ -110,6 +110,7 @@ public class GroupAnalyzerCmd extends CommonDynamicCmd {
 			MultiTreeStatistics.AVG_FRAGMENTATION,
 			MultiTreeStatistics.AVG_REMOTE_ANGLE,
 			MultiTreeStatistics.AVG_PARTITION_ASYMMETRY,
+			MultiTreeStatistics.AVG_FRACTAL_DIMENSION,
 			MultiTreeStatistics.N_BRANCH_POINTS,
 			MultiTreeStatistics.N_TIPS,
 			MultiTreeStatistics.N_BRANCHES,

--- a/src/test/java/sc/fiji/snt/TreeAnalyzerTest.java
+++ b/src/test/java/sc/fiji/snt/TreeAnalyzerTest.java
@@ -80,6 +80,8 @@ public class TreeAnalyzerTest {
 		assertEquals("Avg remote bif angle", 41.3833, avgRemoteBifAngle, precision);
 		final double avgPartitionAsymmetry = analyzer.getAvgPartitionAsymmetry();
 		assertEquals("Avg partition asymmetry", 0.0, avgPartitionAsymmetry, precision);
+		final double avgFractalDimension = analyzer.getAvgFractalDimension();
+		assertEquals("Avg fractal dimension", 1.0146, avgFractalDimension, precision);
 
 		// Scaling tests
 		for (double scaleFactor : new double[] { .25d, 1d, 2d}) {


### PR DESCRIPTION
This PR adds fractal dimension to TreeAnalyzer, TreeStatistics/MultiTreeStatistics and AnalyzerCmd/GroupAnalyzerCmd.

Also adds a corresponding test to TreeAnalyzerTest

The definition of fractal dimension is given by [L-measure](http://cng.gmu.edu:8080/Lm/help/Fractal_Dim.htm), who in turn cite the following primary source:
[Marks, W.B. and Burke, R.E. (2007), Simulation of motoneuron morphology in three dimensions. I. Building individual dendritic trees. J. Comp. Neurol., 503: 685-700. doi:10.1002/cne.21418](https://onlinelibrary.wiley.com/doi/abs/10.1002/cne.21418)