### PR TITLE
Add JUnit test for PersistenceAnalyzer

### DIFF
--- a/src/main/java/sc/fiji/snt/analysis/PersistenceAnalyzer.java
+++ b/src/main/java/sc/fiji/snt/analysis/PersistenceAnalyzer.java
@@ -162,7 +162,7 @@ public class PersistenceAnalyzer {
 	 * @throws IllegalArgumentException If the {@code tree}'s graph could not be
 	 *                                  obtained
 	 */
-	public ArrayList<ArrayList<Double>> getPersistenceDiagram(final String descriptor) throws UnknownMetricException, IllegalArgumentException {
+	public ArrayList<ArrayList<Double>> getDiagram(final String descriptor) throws UnknownMetricException, IllegalArgumentException {
 		if (persistenceDiagramMap.get(descriptor) == null || persistenceDiagramMap.get(descriptor).isEmpty()) {
 			compute(descriptor);
 		}
@@ -177,22 +177,22 @@ public class PersistenceAnalyzer {
 	}
 
 	/**
-	 * Gets the 'bar codes' for the specified filter function.
+	 * Gets the 'barcode' for the specified filter function.
 	 *
 	 * @param descriptor A descriptor for the filter function as per
 	 *                   {@link #getDescriptors()} (case insensitive), such as
 	 *                   {@code radial}, {@code geodesic}, {@code centrifugal}
 	 *                   (reverse Strahler), etc.
-	 * @return the bar codes
+	 * @return the barcode
 	 * @throws UnknownMetricException   If {@code descriptor} is not valid
 	 * @throws IllegalArgumentException If the {@code tree}'s graph could not be
 	 *                                  obtained
 	 */
-	public ArrayList<Double> getBarCodes(final String descriptor) throws UnknownMetricException, IllegalArgumentException {
-		final ArrayList<ArrayList<Double>> diag = getPersistenceDiagram(descriptor);
+	public ArrayList<Double> getBarcode(final String descriptor) throws UnknownMetricException, IllegalArgumentException {
+		final ArrayList<ArrayList<Double>> diag = getDiagram(descriptor);
 		final ArrayList<Double> barcodes = new ArrayList<>(diag.size());
 		diag.forEach(point -> {
-			barcodes.add(point.get(1) - point.get(0));
+			barcodes.add(Math.abs(point.get(1) - point.get(0)));
 		});
 		return barcodes;
 	}
@@ -209,7 +209,7 @@ public class PersistenceAnalyzer {
 	 * @throws IllegalArgumentException If the {@code tree}'s graph could not be
 	 *                                  obtained
 	 */
-	public ArrayList<ArrayList<SWCPoint>> getPersistenceDiagramNodes(final String descriptor) {
+	public ArrayList<ArrayList<SWCPoint>> getDiagramNodes(final String descriptor) {
 		if (persistenceNodesMap.get(descriptor) == null || persistenceNodesMap.get(descriptor).isEmpty())
 			compute(descriptor);
 		final ArrayList<ArrayList<SWCPoint>> nodeDiagram = persistenceNodesMap.get(descriptor);
@@ -230,7 +230,7 @@ public class PersistenceAnalyzer {
      * @param numLandscapes the number of piecewise-linear functions to output.
      * @param resolution the number of samples for all piecewise-linear functions.
 	 */
-	public double[] getPersistenceLandscape(final String descriptor, final int numLandscapes, final int resolution) {
+	public double[] getLandscape(final String descriptor, final int numLandscapes, final int resolution) {
 		if (persistenceDiagramMap.get(descriptor) == null || persistenceDiagramMap.get(descriptor).isEmpty()) {
 			compute(descriptor);
 		}
@@ -403,12 +403,12 @@ public class PersistenceAnalyzer {
 		final SNTService sntService = ij.context().getService(SNTService.class);
 		final Tree tree = sntService.demoTree();
 		final PersistenceAnalyzer analyzer = new PersistenceAnalyzer(tree);
-		final ArrayList<ArrayList<Double>> diagram = analyzer.getPersistenceDiagram("radial");
+		final ArrayList<ArrayList<Double>> diagram = analyzer.getDiagram("radial");
 		for (final ArrayList<Double> point : diagram) {
 			System.out.println(point);
 		}
 		System.out.println(diagram.size());
-		double[] landscape = analyzer.getPersistenceLandscape("radial", 5, 100);
+		double[] landscape = analyzer.getLandscape("radial", 5, 100);
 		System.out.println(landscape.length);
 		
 	}

--- a/src/test/java/sc/fiji/snt/PersistenceAnalyzerTest.java
+++ b/src/test/java/sc/fiji/snt/PersistenceAnalyzerTest.java
@@ -1,0 +1,123 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2019 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeNotNull;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import sc.fiji.snt.analysis.PersistenceAnalyzer;
+import sc.fiji.snt.analysis.TreeAnalyzer;
+import sc.fiji.snt.util.SWCPoint;
+
+/**
+ * Tests for {@link PersistenceAnalyzer}
+ */
+public class PersistenceAnalyzerTest {
+
+	private final double precision = 0.0001;
+	private Tree tree;
+	private PersistenceAnalyzer pAnalyzer;
+	private final List<String> allDescriptors = PersistenceAnalyzer.getDescriptors();
+	private TreeAnalyzer tAnalyzer;
+
+	@Before
+	public void setUp() throws Exception {
+		tree = new SNTService().demoTrees().get(0);
+		pAnalyzer = new PersistenceAnalyzer(tree);
+		tAnalyzer = new TreeAnalyzer(tree);
+		assumeNotNull(tree);
+	}
+
+	@Test
+	public void testDiagram() {
+		// Tests basic validity of the Persistence Diagram for each descriptor function.
+		// TODO devise proper correctness tests for each descriptor.
+		final int numTips = tAnalyzer.getTips().size();
+		for (final String descriptor : allDescriptors) {
+			final ArrayList<ArrayList<Double>> diagram = pAnalyzer.getDiagram(descriptor);
+			assertEquals("Number of points in diagram", numTips, diagram.size());
+			for (final ArrayList<Double> point : diagram) {
+				assertTrue("Two non-negative values per point in diagram",
+						point.size() == 2 && point.get(0) >= 0 && point.get(1) >= 0);
+			}
+		}
+	}
+
+	@Test
+	public void testBarcode() {
+		// Use geodesic descriptor since the sum of all intervals equals total cable length.
+		ArrayList<Double> barcode = pAnalyzer.getBarcode("geodesic");
+		final double cableLength = tAnalyzer.getCableLength();
+		double sumIntervals = 0d;
+		for (final double interval : barcode) {
+			sumIntervals += interval;
+		}
+		assertEquals("Barcode: summed intervals", cableLength, sumIntervals, precision);
+		/*
+		 * For the other descriptors it should be sufficient to demonstrate non-negative
+		 * interval lengths
+		 */
+		for (final String descriptor : allDescriptors) {
+			barcode = pAnalyzer.getBarcode(descriptor);
+			for (final double interval : barcode) {
+				assertTrue("Non-negative intervals", interval >= 0);
+			}
+		}
+	}
+
+	@Test
+	public void testDiagramNodes() {
+		final int numTips = tAnalyzer.getTips().size();
+		for (final String descriptor : allDescriptors) {
+			final ArrayList<ArrayList<SWCPoint>> diagramNodes = pAnalyzer.getDiagramNodes(descriptor);
+			assertEquals("Number of points in diagram", numTips, diagramNodes.size());
+			for (final ArrayList<SWCPoint> point : diagramNodes) {
+				assertTrue("Two SWCPoint objects per point in diagram",
+						point.size() == 2 && point.get(0) instanceof SWCPoint && point.get(1) instanceof SWCPoint);
+			}
+		}
+	}
+
+	@Test
+	public void testLandscape() {
+		for (final String descriptor : allDescriptors) {
+			final double[] landscape = pAnalyzer.getLandscape(descriptor, 5, 100);
+			assertEquals("Landscape size", 500, landscape.length);
+			double minVal = 0;
+			for (int i = 0; i < landscape.length; i++) {
+				if (landscape[i] < minVal) {
+					minVal = landscape[i];
+				}
+			}
+			assertTrue("Landscape: no negative values", minVal >= 0);
+		}
+	}
+
+}


### PR DESCRIPTION
This PR adds a JUnit test for PersistenceAnalyzer.

When writing the test I discovered that the barcodes currently allow for negative intervals (since for certain descriptors features may 'die' before they are 'born'),
so I put in a fix for that as well (just the absolute value of the difference).

Other changes:
 - rename getPersistenceDiagram() to getDiagram()
     - improves API ease-of-use (having "Persistence" in all method names is probably redundant since it is the name of the class)
 - rename getPersistenceDiagramNodes() to getDiagramNodes()
     - same reason as above
 - rename getPersistenceLandscape() to getLandscape()
     - same as above
 - rename getBarCodes() to getBarcode()
     - In the literature I've seen they use 'barcode' (as one word) to refer to the complete set of intervals in a diagram.

Other notes:
 - The tests I added are fairly superficial, in that they only test validity of the basic structure and data types in the diagrams/barcodes/landscapes
 - testing for correctness of each descriptor is less trivial, but maybe worth thinking about?