### PR TITLE
AllenCompartment: change equals() and hashCode() methods

### DIFF
--- a/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
+++ b/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
@@ -26,6 +26,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
@@ -54,12 +55,12 @@ import sc.fiji.snt.viewer.OBJMesh;
  */
 public class AllenCompartment implements BrainAnnotation {
 
-	private String name;
-	private String acronym;
-	private String[] aliases;
-	private int structureId;
-	private UUID uuid;
-	private JSONObject jsonObj;
+	public String name;
+	public String acronym;
+	public String[] aliases;
+	public int structureId;
+	public UUID uuid;
+	public JSONObject jsonObj;
 	private ArrayList<AllenCompartment> parentStructure;
 
 	/**
@@ -341,29 +342,21 @@ public class AllenCompartment implements BrainAnnotation {
 	public String toString() {
 		return name() + " [" + acronym + "]";
 	}
-
-	@Override
-	public boolean equals(final Object o) {
-		if (o == this) return true;
-		if (o == null) return false;
-		if (!(o instanceof AllenCompartment))
-			return false;
-		final AllenCompartment other = ((AllenCompartment) o);
-		// There is really no need to assess uuid: for most instances it will be null
-//		if (uuid != null && other.uuid != null) {
-//			return uuid.equals(other.uuid);
-//		}
-		return id() == other.id();
-	}
-
+	
 	@Override
 	public int hashCode() {
-		if (uuid != null) return uuid.hashCode();
-		int hash = 7;
-		hash = 31 * hash + (int) id();
-		hash = 31 * hash + (acronym == null ? 0 : acronym.hashCode());
-		hash = 31 * hash + (name == null ? 0 : name.hashCode());
-		return hash;
+		return Objects.hash(acronym, structureId);
+	}
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (!(obj instanceof AllenCompartment)) {
+			return false;
+		}
+		AllenCompartment other = (AllenCompartment) obj;
+		return Objects.equals(acronym, other.acronym) && structureId == other.structureId;
 	}
 
 	/* IDE Debug method */

--- a/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
+++ b/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
@@ -347,6 +347,7 @@ public class AllenCompartment implements BrainAnnotation {
 	public int hashCode() {
 		return Objects.hash(acronym, structureId);
 	}
+	
 	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {

--- a/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
+++ b/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
@@ -344,11 +344,6 @@ public class AllenCompartment implements BrainAnnotation {
 	}
 	
 	@Override
-	public int hashCode() {
-		return Objects.hash(acronym, structureId);
-	}
-	
-	@Override
 	public boolean equals(Object obj) {
 		if (this == obj) {
 			return true;
@@ -358,6 +353,11 @@ public class AllenCompartment implements BrainAnnotation {
 		}
 		AllenCompartment other = (AllenCompartment) obj;
 		return Objects.equals(acronym, other.acronym) && structureId == other.structureId;
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hash(acronym, structureId);
 	}
 
 	/* IDE Debug method */

--- a/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
+++ b/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
@@ -55,12 +55,12 @@ import sc.fiji.snt.viewer.OBJMesh;
  */
 public class AllenCompartment implements BrainAnnotation {
 
-	public String name;
-	public String acronym;
-	public String[] aliases;
-	public int structureId;
-	public UUID uuid;
-	public JSONObject jsonObj;
+	private String name;
+	private String acronym;
+	private String[] aliases;
+	private int structureId;
+	private UUID uuid;
+	private JSONObject jsonObj;
 	private ArrayList<AllenCompartment> parentStructure;
 
 	/**


### PR DESCRIPTION
This PR fixes duplicate keys in maps where keys are AllenCompartment objects ( for example, the map returned by ```TreeStatistics.getAnnotatedLength(level)``` )
The new methods were suggested by @tferr 