### PR TITLE
DirectedWeightedGraph: implement shortest paths

### DIFF
--- a/src/main/java/sc/fiji/snt/analysis/graph/DirectedWeightedGraph.java
+++ b/src/main/java/sc/fiji/snt/analysis/graph/DirectedWeightedGraph.java
@@ -22,12 +22,7 @@
 
 package sc.fiji.snt.analysis.graph;
 
-import org.jgrapht.GraphTests;
 import org.jgrapht.Graphs;
-import org.jgrapht.alg.lca.BinaryLiftingLCAFinder;
-import org.jgrapht.alg.lca.EulerTourRMQLCAFinder;
-import org.jgrapht.alg.lca.HeavyPathLCAFinder;
-import org.jgrapht.alg.lca.TarjanLCAFinder;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 import org.jgrapht.traverse.DepthFirstIterator;
 import sc.fiji.snt.Path;

--- a/src/main/resources/script_templates/Neuroanatomy/Analysis/Graph_Analysis.py
+++ b/src/main/resources/script_templates/Neuroanatomy/Analysis/Graph_Analysis.py
@@ -43,11 +43,12 @@ def graph_diameter(graph, root, tips):
 
 
 def graph_diameter_dsp(graph, root, tips):
+    dsp = DijkstraShortestPath(graph)
     max_path_length = 0
     longest_shortest_path = None
     for tip in tips:
         # Use JGraphT's Dijkstra implementation
-        shortest_path = DijkstraShortestPath(graph).getPath(root, tip)
+        shortest_path = dsp.getPath(root, tip)
         path_length = shortest_path.getWeight()
         if path_length > max_path_length:
             max_path_length = path_length

--- a/src/main/resources/script_templates/Neuroanatomy/Analysis/Graph_Analysis.py
+++ b/src/main/resources/script_templates/Neuroanatomy/Analysis/Graph_Analysis.py
@@ -10,7 +10,8 @@ info:       Demonstrates how to handle neurons as graph structures[1] (graph the
             jgrapht[2] library.
             In this demo, the graph diameter[3] (i.e., the length of the longest
             shortest path or the longest graph geodesic) of a cellular compartment
-            is computed for a neuron fetched from the MouseLight database.
+            is computed for a neuron fetched from the MouseLight database, with a 
+            performance comparison between SNT and JgraphT algorithms.
             [1] https://en.wikipedia.org/wiki/Graph_theory
             [2] https://jgrapht.org/
             [3] https://mathworld.wolfram.com/GraphDiameter.html
@@ -23,35 +24,35 @@ from sc.fiji.snt.io import MouseLightLoader
 from sc.fiji.snt.viewer import Viewer3D
 from sc.fiji.snt.analysis.graph import DirectedWeightedGraph
 
-from org.jgrapht import Graphs, GraphPath, GraphTests
 from org.jgrapht.alg.shortestpath import DijkstraShortestPath
 
 
-
-def distanceToRoot(graph, n):
-    """Return graph geodesic distance from node n to tree root."""
-    distance = 0
-    if n.parent == -1:
-        return 0
-    while n.parent != -1:
-        pred = Graphs.predecessorListOf(graph, n)[0]
-        incoming_edge = [edge for edge in graph.incomingEdgesOf(n)][0]
-        weight = graph.getEdgeWeight(incoming_edge)
-        distance += weight
-        n = pred
-    return distance
-
-
-def getTreeDiameter(graph):
-    """Return graph diameter, which for rooted directed trees
+def graph_diameter(graph, root, tips):
+    """Compute graph diameter, which for rooted directed trees
     is the longest shortest path between the root and any terminal node."""
-    tips = graph.getTips()
-    max_dist = 0
+    max_path_length = 0
+    longest_shortest_path = None
     for tip in tips:
-        dist = distanceToRoot(graph, tip)
-        if dist > max_dist:
-            max_dist = dist
-    return max_dist
+        # Use SNT's shortest path algorithm
+        shortest_path = graph.getShortestPath(root, tip)
+        path_length = shortest_path.getLength()
+        if path_length > max_path_length:
+            max_path_length = path_length
+            longest_shortest_path = shortest_path
+    return max_path_length, longest_shortest_path
+
+
+def graph_diameter_dsp(graph, root, tips):
+    max_path_length = 0
+    longest_shortest_path = None
+    for tip in tips:
+        # Use JGraphT's Dijkstra implementation
+        shortest_path = DijkstraShortestPath(graph).getPath(root, tip)
+        path_length = shortest_path.getWeight()
+        if path_length > max_path_length:
+            max_path_length = path_length
+            longest_shortest_path = shortest_path
+    return max_path_length, longest_shortest_path
 
 
 def run():
@@ -63,7 +64,7 @@ def run():
     # Get the SWCPoint representation of each dendritic node, which
     # contains all attributes of a single line in an SWC file.
     print("Extracting dendritic nodes...")
-    dendritic_tree = loader.getTree("dendrite")
+    dendritic_tree = loader.getTree("dendrites")
 
     # Build a jgrapht Graph object from the Tree nodes and assign
     # euclidean distance between adjacent nodes as edge weights.
@@ -78,28 +79,21 @@ def run():
 
     # Retrieve the root: the singular node with in-degree 0
     root = graph.getRoot()
-
-    # Compute the longest shortest path using parent pointers
-    t0 = time.time()
+    # and the tips: the set of nodes with out-degree 0
     tips = graph.getTips()
-    lsp = getTreeDiameter(graph)
-    t1 = time.time()
-    print("Shortest path (PP)=%s. Time: %ss" % (lsp, t1-t0))
 
-    # Compute the longest shortest path using Dijkstra's algorithm,
-    # which allows us to easily get the nodes along the path, albeit
-    # more slowly.
+    # Compute the longest shortest path using SNT
     t0 = time.time()
-    max_dist = 0
-    grapht_path = None
-    for tip in tips:
-        dsp = DijkstraShortestPath(graph)
-        dist = dsp.getPathWeight(root, tip)
-        if dist > max_dist:
-            max_dist = dist
-            grapht_path = dsp.getPath(root, tip)
+    length, path = graph_diameter(graph, root, tips)
     t1 = time.time()
-    print("Shortest path (DSP)=%s. Time: %ss" % (max_dist, t1-t0))
+    print("Graph diameter (SNT)=%s. Time: %ss" % (length, t1-t0))
+
+    # Compute the longest shortest path using JGrapht Dijkstra's algorithm,
+    # which is slower with larger inputs (i.e., an axon tree)
+    t0 = time.time()
+    length, _ = graph_diameter_dsp(graph, root, tips)
+    t1 = time.time()
+    print("Graph diameter (DSP)=%s. Time: %ss" % (length, t1-t0))
 
     # Visualize the longest path in Viewer3D (interactive instance)
     viewer = Viewer3D(context)
@@ -108,13 +102,13 @@ def run():
     dendritic_tree.setColor("cyan")
     viewer.add(dendritic_tree)
 
-    shortest_path_vertices = grapht_path.getVertexList()
-    snt_tree_shortest_path = Tree(shortest_path_vertices, "Dijkstra shortest path")
+    snt_tree_shortest_path = Tree([path])
     snt_tree_shortest_path.setColor("orange")
 
     # Highlight the shortest path by offsetting it laterally by 10um
     snt_tree_shortest_path.translate(10,10,0)
     viewer.add(snt_tree_shortest_path)
     viewer.show()
+
 
 run()


### PR DESCRIPTION
- add corresponding test to DirectedWeightedGraphTest
- modernize graph analysis script template
- misc. code cleanup and performance improvements
  - most notably, remove redundancy in ```DirectedWeightedGraph.getRoot()``` providing a speed up in several places