### PR TITLE
Resolve #47

### DIFF
--- a/src/main/java/sc/fiji/snt/annotation/AllenUtils.java
+++ b/src/main/java/sc/fiji/snt/annotation/AllenUtils.java
@@ -21,30 +21,10 @@
  */
 package sc.fiji.snt.annotation;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
-
-import javax.swing.tree.DefaultMutableTreeNode;
-import javax.swing.tree.DefaultTreeModel;
-import javax.swing.tree.TreeNode;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
 import org.scijava.util.ColorRGB;
-
 import sc.fiji.snt.Path;
 import sc.fiji.snt.Tree;
 import sc.fiji.snt.analysis.graph.DirectedWeightedGraph;
@@ -53,10 +33,19 @@ import sc.fiji.snt.util.PointInImage;
 import sc.fiji.snt.util.SNTPoint;
 import sc.fiji.snt.viewer.OBJMesh;
 
+import javax.swing.tree.DefaultMutableTreeNode;
+import javax.swing.tree.DefaultTreeModel;
+import javax.swing.tree.TreeNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.*;
+
 /**
  * Utility methods for accessing/handling {@link AllenCompartment}s
  * 
  * @author Tiago Ferreira
+ * @author Cameron Arshadi
  */
 public class AllenUtils {
 
@@ -168,8 +157,8 @@ public class AllenUtils {
 	}
 
 	private static double[] crossProduct(double[] a, double[] b) {
-		if (a.length != b.length || a.length != 3 || b.length != 3) {
-			throw new IllegalArgumentException("Vectors a and b are not of equal length or are not 3-dimensional");
+		if (a.length != 3 || b.length != 3) {
+			throw new IllegalArgumentException("Vectors a and b must be 3-dimensional");
 		}
 		double[] c = new double[3];
 		c[0] = a[1] * b[2] - a[2] * b[1];
@@ -197,7 +186,7 @@ public class AllenUtils {
 		double norm = euclideanNorm(v);
 		double[] normalized = new double[v.length];
 		for (int i = 0; i < v.length; i++) {
-			normalized[i] = (double) v[i] / norm;
+			normalized[i] = v[i] / norm;
 		}
 		return normalized;
 	}
@@ -220,11 +209,10 @@ public class AllenUtils {
 		double d = -1 * a * planePoint[0] - b * planePoint[1] - c * planePoint[2];
 		// We need to use an affine transformation instead of linear
 		// since the plane of reflection does not go through the origin.
-		double[][] A = { {  1-2*a*a, -2*a*b,   -2*a*c,   -2*a*d },
+		return new double[][]{ {  1-2*a*a, -2*a*b,   -2*a*c,   -2*a*d },
 				{ -2*a*b,    1-2*b*b, -2*b*c,   -2*b*d },
-				{ -2*a*c,   -2*b*c,    1-2*c*c, -2*c*d }, 
+				{ -2*a*c,   -2*b*c,    1-2*c*c, -2*c*d },
 				{  0,        0,        0,        1 } };
-		return A;
 	}
 
 	/**
@@ -275,9 +263,10 @@ public class AllenUtils {
 	}
 
 	public static void assignHemisphereTags(final DirectedWeightedGraph graph) {
-		graph.vertexSet().forEach(node -> {
-			node.setHemisphere(isLeftHemisphere(node) ? BrainAnnotation.LEFT_HEMISPHERE : BrainAnnotation.RIGHT_HEMISPHERE);
-		});
+		graph.vertexSet().forEach(node ->
+				node.setHemisphere(
+						isLeftHemisphere(node) ? BrainAnnotation.LEFT_HEMISPHERE : BrainAnnotation.RIGHT_HEMISPHERE
+				));
 	}
 
 	/**
@@ -285,15 +274,17 @@ public class AllenUtils {
 	 *
 	 * @return the axis defining mid sagittal plane where X=0; Y=1; Z=2;
 	 */
+	@SuppressWarnings("SameReturnValue")
 	public static int getAxisDefiningMidSagittalPlane() {
 		return 0;
 	}
 
 	public static void assignHemisphereTags(final Tree tree) {
 		//TODO: Currently we have to tag both the tree nodes and graph vertices. This needs to be simplified!
-		tree.getNodes().forEach(node -> {
-			node.setHemisphere(isLeftHemisphere(node) ? BrainAnnotation.LEFT_HEMISPHERE : BrainAnnotation.RIGHT_HEMISPHERE);
-		});
+		tree.getNodes().forEach(node ->
+				node.setHemisphere(
+						isLeftHemisphere(node) ? BrainAnnotation.LEFT_HEMISPHERE : BrainAnnotation.RIGHT_HEMISPHERE
+				));
 		assignHemisphereTags(tree.getGraph());
 	}
 
@@ -334,6 +325,7 @@ public class AllenUtils {
 	 * 
 	 * @return the max number of ontology levels.
 	 */
+	@SuppressWarnings("SameReturnValue")
 	public static int getHighestOntologyDepth() {
 		// No need to compute, as this is unlikely to change
 		return 10; // computeHighestOntologyDepth();
@@ -364,7 +356,7 @@ public class AllenUtils {
 	 *
 	 * @return the "flattened" ontologies list
 	 */
-	public static Collection<AllenCompartment> getOntologies() {
+	public static List<AllenCompartment> getOntologies() {
 		return new AllenTreeModel().getOntologies();
 	}
 
@@ -380,12 +372,11 @@ public class AllenUtils {
 
 		private AllenCompartment getAreaListCompartment(final int idx) {
 			final JSONObject area = (JSONObject) areaList.get(idx);
-			final AllenCompartment ac = new AllenCompartment(UUID.fromString(area.getString("id")));
-			return ac;
+			return new AllenCompartment(UUID.fromString(area.getString("id")));
 		}
 
-		private Collection<AllenCompartment> getOntologies() {
-			final Collection<AllenCompartment> list = new ArrayList<>(areaList.length());
+		private List<AllenCompartment> getOntologies() {
+			final List<AllenCompartment> list = new ArrayList<>(areaList.length());
 			for (int n = 0; n < areaList.length(); n++) {
 				list.add(getAreaListCompartment(n));
 			}
@@ -394,7 +385,7 @@ public class AllenUtils {
 
 		private DefaultTreeModel getTreeModel(final boolean meshesOnly) {
 			final TreeSet<AllenCompartment> all = new TreeSet<>(
-					(ac1, ac2) -> ac1.getStructureIdPath().compareTo(ac2.getStructureIdPath()));
+					Comparator.comparing(AllenCompartment::getStructureIdPath));
 			final Map<Integer, AllenCompartment> idsMap = new HashMap<>();
 			final Set<Integer> visitedIds = new HashSet<>();
 			root = new DefaultMutableTreeNode();
@@ -464,6 +455,7 @@ public class AllenUtils {
 			throw new IllegalArgumentException(meshLabel + " not found");
 		final OBJMesh mesh = new OBJMesh(url, "um");
 		mesh.setColor(color, 95f);
+		mesh.setVolume(513578693035.138d); // pre-computed surface integral
 		mesh.setLabel(meshLabel);
 		return mesh;
 	}

--- a/src/test/java/sc/fiji/snt/annotation/AllenCompartmentTest.java
+++ b/src/test/java/sc/fiji/snt/annotation/AllenCompartmentTest.java
@@ -132,7 +132,6 @@ public class AllenCompartmentTest {
             assertEquals(rootCompartment.hashCode(), new AllenCompartment(ROOT_STRUCTURE_ID).hashCode());
             assertEquals(rootCompartment.hashCode(), new AllenCompartment(ROOT_UUID).hashCode());
             assertEquals(rootCompartment.hashCode(), new AllenCompartment(ROOT_JSON_OBJECT, ROOT_UUID).hashCode());
-
         }
 
     }
@@ -183,12 +182,12 @@ public class AllenCompartmentTest {
                     .map(AllenCompartment::new)
                     .collect(Collectors.toList());
             for (int i = 0; i < compartmentList.size() - 1; i++) {
-                AllenCompartment parent = compartmentList.get(i);
-                for (AllenCompartment child : compartmentList.subList(i + 1, compartmentList.size())) {
+                final AllenCompartment parent = compartmentList.get(i);
+                for (final AllenCompartment child : compartmentList.subList(i + 1, compartmentList.size())) {
                     assertTrue(child.isChildOf(parent));
                 }
             }
-            AllenCompartment compartment = compartmentList.get(1);
+            final AllenCompartment compartment = compartmentList.get(1);
             assertFalse(compartment.isChildOf(new AllenCompartment(treePath.get(1))));
             assertFalse(compartment.isChildOf(compartmentList.get(2)));
         }
@@ -200,12 +199,12 @@ public class AllenCompartmentTest {
                     .map(AllenCompartment::new)
                     .collect(Collectors.toList());
             for (int i = 0; i < compartmentList.size() - 1; i++) {
-                AllenCompartment parent = compartmentList.get(i);
-                for (AllenCompartment child : compartmentList.subList(i + 1, compartmentList.size())) {
+                final AllenCompartment parent = compartmentList.get(i);
+                for (final AllenCompartment child : compartmentList.subList(i + 1, compartmentList.size())) {
                     assertTrue(parent.isParentOf(child));
                 }
             }
-            AllenCompartment compartment = compartmentList.get(1);
+            final AllenCompartment compartment = compartmentList.get(1);
             assertFalse(compartment.isParentOf(new AllenCompartment(treePath.get(1))));
             assertFalse(compartment.isParentOf(compartmentList.get(0)));
         }

--- a/src/test/java/sc/fiji/snt/annotation/AllenCompartmentTest.java
+++ b/src/test/java/sc/fiji/snt/annotation/AllenCompartmentTest.java
@@ -1,0 +1,238 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2020 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.annotation;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import sc.fiji.snt.viewer.OBJMesh;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+
+/**
+ * Tests for {@link AllenCompartment}
+ *
+ * @author Cameron Arshadi
+ */
+@RunWith(Enclosed.class)
+public class AllenCompartmentTest {
+
+    @RunWith(Parameterized.class)
+    public static class ParameterizedTests {
+
+        private static final String ROOT_UUID_STRING = "464cb1ee-4664-40dc-948f-85dd1feb3e40";
+        private static final UUID ROOT_UUID = UUID.fromString(ROOT_UUID_STRING);
+        private static final JSONObject ROOT_JSON_OBJECT = AllenUtils.getBrainAreasByUUID().getJSONObject(ROOT_UUID_STRING);
+        private static final int ROOT_STRUCTURE_ID = 997;
+
+        @Parameterized.Parameters
+        public static Iterable<AllenCompartment> data() {
+            return Arrays.asList(
+                    new AllenCompartment(ROOT_UUID),
+                    new AllenCompartment(ROOT_STRUCTURE_ID),
+                    new AllenCompartment(ROOT_JSON_OBJECT, ROOT_UUID)
+            );
+        }
+
+        @Parameterized.Parameter
+        public AllenCompartment rootCompartment;
+
+        @Test
+        public void testName() {
+            assertEquals("Whole Brain", rootCompartment.name());
+        }
+
+        @Test
+        public void testUUID() {
+            assertEquals(ROOT_UUID, rootCompartment.getUUID());
+        }
+
+        @Test
+        public void testId() {
+            assertEquals(ROOT_STRUCTURE_ID, rootCompartment.id());
+        }
+
+        @Test
+        public void testDepth() {
+            assertEquals(0, rootCompartment.depth());
+        }
+
+        @Test
+        public void testAcronym() {
+            assertEquals("brain", rootCompartment.acronym());
+        }
+
+        @Test
+        public void testAliases() {
+            assertEquals(0, rootCompartment.aliases().length);
+        }
+
+        @Test
+        public void testIsMeshAvailable() {
+            assertTrue(rootCompartment.isMeshAvailable());
+        }
+
+        @Test
+        public void testGetParent() {
+            assertEquals(500, new AllenCompartment(985).getParent().id());
+            assertNull(rootCompartment.getParent());
+        }
+
+        @Test
+        public void testGetChildren() {
+            assertEquals(AllenUtils.getOntologies().size() - 1, rootCompartment.getChildren().size());
+        }
+
+        @Test
+        public void testGetChildrenInteger() {
+            final Set<Integer> expectedChildren = new HashSet<>(Arrays.asList(1024, 73, 1009, 8, 304325711));
+            final Set<Integer> actualChildren = rootCompartment.getChildren(1).stream()
+                    .map(AllenCompartment::id)
+                    .collect(Collectors.toSet());
+            assertEquals(expectedChildren, actualChildren);
+        }
+
+        @Test
+        public void testEquals() {
+            assertEquals(rootCompartment, rootCompartment);
+            assertEquals(rootCompartment, new AllenCompartment(ROOT_STRUCTURE_ID));
+            assertEquals(rootCompartment, new AllenCompartment(ROOT_UUID));
+            assertEquals(rootCompartment, new AllenCompartment(ROOT_JSON_OBJECT, ROOT_UUID));
+            assertNotEquals(rootCompartment, new AllenCompartment(1024));
+        }
+
+        @Test
+        public void testHashCode() {
+            assertEquals(rootCompartment.hashCode(), new AllenCompartment(ROOT_STRUCTURE_ID).hashCode());
+            assertEquals(rootCompartment.hashCode(), new AllenCompartment(ROOT_UUID).hashCode());
+            assertEquals(rootCompartment.hashCode(), new AllenCompartment(ROOT_JSON_OBJECT, ROOT_UUID).hashCode());
+
+        }
+
+    }
+
+    public static class SingleTests {
+
+        @Test
+        public void testGetAncestorInteger() {
+            final List<Integer> treePath = Arrays.asList(997, 8, 567, 688, 695, 315, 453, 322, 329, 480149202, 480149206);
+            Collections.reverse(treePath);
+            // Rostrolateral lateral visual area, layer 1
+            final AllenCompartment compartment = new AllenCompartment(480149206);
+            for (int i = 1; i < compartment.getOntologyDepth() + 1; i++) {
+                AllenCompartment an = compartment.getAncestor(i);
+                assertEquals((int) treePath.get(i), an.id());
+                an = compartment.getAncestor(-i);
+                assertEquals((int) treePath.get(i), an.id());
+            }
+        }
+
+        @Test
+        public void testGetAncestors() {
+            final List<Integer> ancestorsExpected = Arrays.asList(997, 8, 567, 688, 695, 315, 453, 322, 329, 480149202);
+            // Rostrolateral lateral visual area, layer 1
+            final List<Integer> ancestorsActual = new AllenCompartment(480149206).getAncestors().stream()
+                    .map(AllenCompartment::id)
+                    .collect(Collectors.toList());
+            assertEquals(ancestorsExpected, ancestorsActual);
+        }
+
+        @Test
+        public void testGetTreePath() {
+            final List<Integer> treePathExpected = Arrays.asList(
+                    997, 8, 567, 688, 695, 315, 453, 322, 329, 480149202, 480149206
+            );
+            // Rostrolateral lateral visual area, layer 1
+            final List<Integer> treePathActual = new AllenCompartment(480149206).getTreePath().stream()
+                    .map(AllenCompartment::id)
+                    .collect(Collectors.toList());
+            assertEquals(treePathExpected, treePathActual);
+        }
+
+
+        @Test
+        public void testIsChildOf() {
+            final List<Integer> treePath = Arrays.asList(997, 8, 567, 688, 695, 315, 453, 322, 329, 480149202, 480149206);
+            final List<AllenCompartment> compartmentList = treePath.stream()
+                    .map(AllenCompartment::new)
+                    .collect(Collectors.toList());
+            for (int i = 0; i < compartmentList.size() - 1; i++) {
+                AllenCompartment parent = compartmentList.get(i);
+                for (AllenCompartment child : compartmentList.subList(i + 1, compartmentList.size())) {
+                    assertTrue(child.isChildOf(parent));
+                }
+            }
+            AllenCompartment compartment = compartmentList.get(1);
+            assertFalse(compartment.isChildOf(new AllenCompartment(treePath.get(1))));
+            assertFalse(compartment.isChildOf(compartmentList.get(2)));
+        }
+
+        @Test
+        public void testIsParentOf() {
+            final List<Integer> treePath = Arrays.asList(997, 8, 567, 688, 695, 315, 453, 322, 329, 480149202, 480149206);
+            final List<AllenCompartment> compartmentList = treePath.stream()
+                    .map(AllenCompartment::new)
+                    .collect(Collectors.toList());
+            for (int i = 0; i < compartmentList.size() - 1; i++) {
+                AllenCompartment parent = compartmentList.get(i);
+                for (AllenCompartment child : compartmentList.subList(i + 1, compartmentList.size())) {
+                    assertTrue(parent.isParentOf(child));
+                }
+            }
+            AllenCompartment compartment = compartmentList.get(1);
+            assertFalse(compartment.isParentOf(new AllenCompartment(treePath.get(1))));
+            assertFalse(compartment.isParentOf(compartmentList.get(0)));
+        }
+
+        @Test
+        public void testGetOntologyDepth() {
+            // Parabrachial nucleus, lateral division, dorsal lateral part
+            final AllenCompartment compartment = new AllenCompartment(868);
+            assertEquals(8, compartment.getOntologyDepth());
+        }
+
+        @Test
+        public void testGetMesh() {
+            // Parabrachial nucleus, lateral division, dorsal lateral part
+            AllenCompartment compartment = new AllenCompartment(868);
+            assertFalse(compartment.isMeshAvailable());
+            OBJMesh mesh = compartment.getMesh();
+            assertNull(mesh);
+
+            // Primary somatosensory area, upper limb, layer 5
+            compartment = new AllenCompartment(625);
+            assertTrue(compartment.isMeshAvailable());
+            mesh = compartment.getMesh();
+            assertNotNull(mesh);
+            assertEquals(1305537356.8650255d, mesh.getVolume(), 0.0000001);
+        }
+
+    }
+
+}

--- a/src/test/java/sc/fiji/snt/annotation/AllenUtilsTest.java
+++ b/src/test/java/sc/fiji/snt/annotation/AllenUtilsTest.java
@@ -46,35 +46,35 @@ public class AllenUtilsTest {
 
     @Test
     public void testGetBrainAreasList() {
-        JSONArray brainAreasList = AllenUtils.getBrainAreasList();
+        final JSONArray brainAreasList = AllenUtils.getBrainAreasList();
         assertEquals(1287, brainAreasList.length());
         for (int i = 0; i < brainAreasList.length(); i++) {
-            JSONObject jsonObject = brainAreasList.getJSONObject(i);
+            final JSONObject jsonObject = brainAreasList.getJSONObject(i);
             testJSONObject(jsonObject);
         }
     }
 
     @Test
     public void testGetBrainAreasByStructureId() {
-        JSONObject brainAreas = AllenUtils.getBrainAreasByStructureId();
+        final JSONObject brainAreas = AllenUtils.getBrainAreasByStructureId();
         assertEquals(1287, brainAreas.length());
-        Iterator<String> ids = brainAreas.keys();
+        final Iterator<String> ids = brainAreas.keys();
         while (ids.hasNext()) {
-            String idString = ids.next();
-            int idInt = Integer.parseInt(idString); // just check if an Integer is parsable
-            JSONObject jsonObj = brainAreas.getJSONObject(idString);
+            final String idString = ids.next();
+            final int idInt = Integer.parseInt(idString); // just check if an Integer is parsable
+            final JSONObject jsonObj = brainAreas.getJSONObject(idString);
             testJSONObject(jsonObj);
         }
     }
 
     @Test
     public void testGetBrainAreasByUUID() {
-        JSONObject brainAreas = AllenUtils.getBrainAreasByUUID();
+        final JSONObject brainAreas = AllenUtils.getBrainAreasByUUID();
         assertEquals(1287, brainAreas.length());
-        Iterator<String> uuids = brainAreas.keys();
+        final Iterator<String> uuids = brainAreas.keys();
         while (uuids.hasNext()) {
-            String uuidString = uuids.next();
-            JSONObject jsonObj = brainAreas.getJSONObject(uuidString);
+            final String uuidString = uuids.next();
+            final JSONObject jsonObj = brainAreas.getJSONObject(uuidString);
             testJSONObject(jsonObj);
         }
     }

--- a/src/test/java/sc/fiji/snt/annotation/AllenUtilsTest.java
+++ b/src/test/java/sc/fiji/snt/annotation/AllenUtilsTest.java
@@ -1,0 +1,118 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2020 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.annotation;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for {@link AllenUtils}
+ *
+ * @author Cameron Arshadi
+ */
+public class AllenUtilsTest {
+
+    @Test
+    public void testGetOntologies() {
+        final List<AllenCompartment> ontologies = AllenUtils.getOntologies();
+        assertEquals(1287, ontologies.size());
+    }
+
+    @Test
+    public void testGetBrainAreasList() {
+        JSONArray brainAreasList = AllenUtils.getBrainAreasList();
+        assertEquals(1287, brainAreasList.length());
+        for (int i = 0; i < brainAreasList.length(); i++) {
+            JSONObject jsonObject = brainAreasList.getJSONObject(i);
+            testJSONObject(jsonObject);
+        }
+    }
+
+    @Test
+    public void testGetBrainAreasByStructureId() {
+        JSONObject brainAreas = AllenUtils.getBrainAreasByStructureId();
+        assertEquals(1287, brainAreas.length());
+        Iterator<String> ids = brainAreas.keys();
+        while (ids.hasNext()) {
+            String idString = ids.next();
+            int idInt = Integer.parseInt(idString); // just check if an Integer is parsable
+            JSONObject jsonObj = brainAreas.getJSONObject(idString);
+            testJSONObject(jsonObj);
+        }
+    }
+
+    @Test
+    public void testGetBrainAreasByUUID() {
+        JSONObject brainAreas = AllenUtils.getBrainAreasByUUID();
+        assertEquals(1287, brainAreas.length());
+        Iterator<String> uuids = brainAreas.keys();
+        while (uuids.hasNext()) {
+            String uuidString = uuids.next();
+            JSONObject jsonObj = brainAreas.getJSONObject(uuidString);
+            testJSONObject(jsonObj);
+        }
+    }
+
+    private void testJSONObject(final JSONObject jsonObject) {
+        assertFalse(jsonObject.getString("id").isEmpty());
+
+        assertFalse(jsonObject.getString("name").isEmpty());
+
+        assertTrue(jsonObject.get("structureId") instanceof Integer);
+
+        assertTrue(jsonObject.get("depth") instanceof Integer);
+
+        assertTrue(jsonObject.get("parentStructureId") instanceof Integer ||
+                JSONObject.NULL.equals(jsonObject.get("parentStructureId")));
+
+        assertFalse(jsonObject.getString("structureIdPath").isEmpty());
+
+        assertFalse(jsonObject.getString("safeName").isEmpty());
+
+        assertFalse(jsonObject.getString("acronym").isEmpty());
+
+        assertTrue(jsonObject.get("aliases") instanceof JSONArray);
+
+        assertTrue(jsonObject.get("atlasId") instanceof Integer ||
+                JSONObject.NULL.equals(jsonObject.get("atlasId")));
+
+        assertTrue(jsonObject.get("graphOrder") instanceof Integer ||
+                JSONObject.NULL.equals(jsonObject.get("graphOrder")));
+
+        assertFalse(jsonObject.getString("geometryFile").isEmpty());
+
+        assertFalse(jsonObject.getString("geometryColor").isEmpty());
+
+        assertTrue(jsonObject.get("geometryEnable") instanceof Boolean);
+
+        assertTrue(JSONObject.NULL.equals(jsonObject.get("geometryVolume")) ||
+                jsonObject.getDouble("geometryVolume") > 0);
+    }
+
+}


### PR DESCRIPTION
Resolve #47 

- ensure `parentStructure` attribute is initialized by calling `AllenCompartment.getTreePath()`
- fix bug in `AllenCompartment.getChildren(final int level)`
- set pre-computed volume for mouse brain root `OBJMesh`
- `AllenUtils.getOntologies()` returns `List` instead of `Collection`
- create tests for `AllenCompartment` and `AllenUtils`
- misc code cleanup

pinging @tferr 