### PR TITLE
Explicitly declare skeletonizeImp parameter global

### DIFF
--- a/src/main/resources/script_templates/Neuroanatomy/Skeletons_and_ROIs/Reconstruction_From_Segmented_Image.py
+++ b/src/main/resources/script_templates/Neuroanatomy/Skeletons_and_ROIs/Reconstruction_From_Segmented_Image.py
@@ -32,6 +32,7 @@ def get_sample_image():
 
 
 def main():
+	global skeletonizeImp
 	if choice == "Current image":
 		imp = IJ.getImage()
 	elif choice == "Image from path specified below":


### PR DESCRIPTION
As `skeletonizeImp` is assigned in some but not all code paths, the Jython interpreter might throw an `UnboundLocalError`.
See https://forum.image.sc/t/snt-problem-with-script-for-reconstruction-from-segmented-images/52501/4?u=imagejan
Explicitly declaring `skeletonizeImp` to be `global` helps to avoid the error.