### PR TITLE
Local neighborhood profiling and new Cursor<T>s

### DIFF
--- a/src/main/java/sc/fiji/snt/Path.java
+++ b/src/main/java/sc/fiji/snt/Path.java
@@ -1863,7 +1863,7 @@ public class Path implements Comparable<Path> {
 		}
 	}
 
-	protected void getTangent(final int i, final int pointsEitherSide,
+	public void getTangent(final int i, final int pointsEitherSide,
 		final double[] result)
 	{
 		int min_index = i - pointsEitherSide;

--- a/src/main/java/sc/fiji/snt/analysis/ProfileProcessor.java
+++ b/src/main/java/sc/fiji/snt/analysis/ProfileProcessor.java
@@ -1,0 +1,413 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2021 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.analysis;
+
+import ij.ImagePlus;
+import ij.measure.Calibration;
+import net.imagej.ImageJ;
+import net.imglib2.*;
+import net.imglib2.algorithm.region.CircleCursor;
+import net.imglib2.algorithm.region.hypersphere.HyperSphere;
+import net.imglib2.img.Img;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.LinAlgHelpers;
+import net.imglib2.util.Util;
+import sc.fiji.snt.Path;
+import sc.fiji.snt.SNTService;
+import sc.fiji.snt.Tree;
+import sc.fiji.snt.util.*;
+import smile.math.MathEx;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * Profile intensities within local neighborhoods around {@link Path} {@link sc.fiji.snt.util.PointInImage}s
+ *
+ * @author Cameron Arshadi
+ */
+public class ProfileProcessor< T extends RealType< T > > implements Callable< double[] >
+{
+
+    private final RandomAccessibleInterval< T > rai;
+    private final Path path;
+    private final double avgSep;
+    private final long[] intervalMin;
+    private final long[] intervalMax;
+    private Metric metric = Metric.SUM;
+    private Shape shape = Shape.HYPERSPHERE;
+    private boolean useNodeRadii = true;
+    private int radius = 1;
+    private double[] values;
+
+    public enum Metric {SUM, MIN, MAX, MEAN, MEDIAN, VARIANCE}
+
+    public enum Shape {HYPERSPHERE, CIRCLE, DISK, PATH}
+
+    public ProfileProcessor( final RandomAccessibleInterval< T > rai, final Path path )
+    {
+        this.path = path;
+        this.rai = rai;
+        this.intervalMin = Intervals.minAsLongArray( rai );
+        this.intervalMax = Intervals.maxAsLongArray( rai );
+        final Calibration cal = path.getCalibration();
+        if ( rai.numDimensions() == 2 )
+        {
+            avgSep = ( cal.pixelWidth + cal.pixelHeight ) / 2;
+        }
+        else
+        {
+            avgSep = ( cal.pixelWidth + cal.pixelHeight + cal.pixelDepth ) / 3;
+        }
+    }
+
+    /**
+     * Sets the metric to be computed for each local neighborhood. This setting is ignored if using
+     * {@link Shape#PATH}.
+     *
+     * @param metric
+     */
+    public void setMetric( final Metric metric )
+    {
+        this.metric = metric;
+    }
+
+    /**
+     * Sets the shape to be iterated.
+     *
+     * @param shape
+     */
+    public void setShape( final Shape shape )
+    {
+        this.shape = shape;
+    }
+
+    /**
+     * Set whether or not to use the {@link PointInImage} radius (scaled in pixels) as the {@link Shape} radius.
+     *
+     * @param useNodeRadii
+     */
+    public void setUseNodeRadii( final boolean useNodeRadii )
+    {
+        this.useNodeRadii = useNodeRadii;
+    }
+
+    /**
+     * Specify a fixed radius for each {@link Shape} region around each {@link PointInImage}. This setting
+     * is only used if setUseNodeRadii is false.
+     *
+     * @param radius
+     */
+    public void setRadius( final int radius )
+    {
+        this.radius = radius;
+    }
+
+    /**
+     * The profile values, or null if they have not been processed yet.
+     *
+     * @return the values
+     */
+    public double[] getValues()
+    {
+        return values;
+    }
+
+    public void process()
+    {
+        call();
+    }
+
+    /**
+     * Process and return the profile values.
+     *
+     * @return the values.
+     */
+    @Override
+    public double[] call()
+    {
+        values = new double[ path.size() ];
+        if ( path.size() == 1 )
+        {
+            return values;
+        }
+        if ( shape == Shape.PATH )
+        {
+            return profilePathNodes( rai, path, values );
+        }
+        for ( int i = 0; i < path.size(); ++i )
+        {
+            long r = useNodeRadii ? Math.round( path.getNodeRadius( i ) / avgSep ) : radius;
+            if ( r < 1 )
+                r = 1;
+
+            final Cursor< T > cursor = getSuitableCursor( rai, shape, r, path, i );
+            if ( cursor == null )
+                continue;
+
+            final double value;
+            switch ( metric )
+            {
+                case SUM:
+                    value = sum( cursor );
+                    break;
+                case MIN:
+                    value = min( cursor );
+                    break;
+                case MAX:
+                    value = max( cursor );
+                    break;
+                case MEAN:
+                    value = mean( cursor );
+                    break;
+                case MEDIAN:
+                    value = median( cursor );
+                    break;
+                case VARIANCE:
+                    value = variance( cursor );
+                    break;
+                default:
+                    throw new IllegalArgumentException( "Unknown profiler method: " + metric );
+            }
+            values[ i ] = value;
+        }
+        return values;
+    }
+
+    private static < T extends RealType< T > > double[] profilePathNodes( final RandomAccessible< T > rai,
+                                                                          final Path path, final double[] values )
+    {
+        // just return the node values
+        final PathCursor< T > cursor = new PathCursor<>( rai, path );
+        int i = 0;
+        while ( cursor.hasNext() )
+        {
+            values[ i++ ] = cursor.next().getRealDouble();
+        }
+        return values;
+    }
+
+    private static double[] getPlaneNormal( final Path path, final int i )
+    {
+        double[] tangent = new double[ 3 ];
+        path.getTangent( i, 1, tangent );
+        if ( Arrays.stream( tangent ).allMatch( e -> e == 0 ) )
+        {
+            return null;
+        }
+        LinAlgHelpers.normalize( tangent );
+        return tangent;
+    }
+
+    private static < T > Cursor< T > getSuitableCursor( final RandomAccessible< T > rai, final Shape shape,
+                                                        final long radius, final Path path, final int i )
+    {
+        if ( rai.numDimensions() == 2 )
+        {
+            return getSuitableCursor2d( rai, shape, radius, path, i );
+        }
+        return getSuitableCursor3d( rai, shape, radius, path, i );
+    }
+
+    private static < T > Cursor< T > getSuitableCursor2d( final RandomAccessible< T > rai, final Shape shape,
+                                                          final long radius, final Path path, final int i )
+    {
+        final Localizable centerPoint = new Point( path.getXUnscaled( i ), path.getYUnscaled( i ) );
+        switch ( shape )
+        {
+            case CIRCLE:
+                return new CircleCursor<>( rai, centerPoint, radius );
+            case HYPERSPHERE:
+            case DISK:
+                return new HyperSphere<>( rai, centerPoint, radius ).cursor();
+            case PATH:
+            default:
+                throw new IllegalArgumentException( "Unsupported shape: " + shape );
+
+        }
+    }
+
+    private static < T > Cursor< T > getSuitableCursor3d( final RandomAccessible< T > rai, final Shape shape,
+                                                          final long radius, final Path path, final int i )
+    {
+        final Localizable centerPoint = new Point( path.getXUnscaled( i ), path.getYUnscaled( i ),
+                path.getZUnscaled( i ) );
+        switch ( shape )
+        {
+            case CIRCLE:
+            {
+                double[] circleNormal = getPlaneNormal( path, i );
+                if ( circleNormal == null )
+                    return null;
+                return new CircleCursor3d<>( rai, centerPoint, radius, circleNormal );
+            }
+
+            case HYPERSPHERE:
+            {
+                return new HyperSphere<>( rai, centerPoint, radius ).cursor();
+            }
+
+            case DISK:
+            {
+                double[] circleNormal = getPlaneNormal( path, i );
+                if ( circleNormal == null )
+                    return null;
+                return new DiskCursor3d<>( rai, centerPoint, radius, circleNormal );
+            }
+            case PATH:
+            default:
+                throw new IllegalArgumentException( "Unsupported shape: " + shape );
+
+        }
+    }
+
+    private static boolean outOfBounds( final long[] pos, final long[] min, final long[] max )
+    {
+        for ( int d = 0; d < pos.length; d++ )
+            if ( pos[ d ] < min[ d ] || pos[ d ] > max[ d ] )
+                return true;
+        return false;
+    }
+
+    private double sum( final Cursor< ? extends RealType< ? > > cursor )
+    {
+        final long[] pos = new long[ cursor.numDimensions() ];
+        double sum = 0;
+        while ( cursor.hasNext() )
+        {
+            cursor.fwd();
+            cursor.localize( pos );
+            if ( outOfBounds( pos, intervalMin, intervalMax ) )
+                continue;
+            sum += cursor.get().getRealDouble();
+        }
+        return sum;
+    }
+
+    private double min( final Cursor< ? extends RealType< ? > > cursor )
+    {
+        final long[] pos = new long[ cursor.numDimensions() ];
+        double min = Double.MAX_VALUE;
+        while ( cursor.hasNext() )
+        {
+            cursor.fwd();
+            cursor.localize( pos );
+            if ( outOfBounds( pos, intervalMin, intervalMax ) )
+                continue;
+            min = Math.min( min, cursor.get().getRealDouble() );
+        }
+        return min;
+    }
+
+    private double max( final Cursor< ? extends RealType< ? > > cursor )
+    {
+        final long[] pos = new long[ cursor.numDimensions() ];
+        double max = -Double.MAX_VALUE;
+        while ( cursor.hasNext() )
+        {
+            cursor.fwd();
+            cursor.localize( pos );
+            if ( outOfBounds( pos, intervalMin, intervalMax ) )
+                continue;
+            max = Math.max( max, cursor.get().getRealDouble() );
+        }
+        return max;
+    }
+
+    private double mean( final Cursor< ? extends RealType< ? > > cursor )
+    {
+        final long[] pos = new long[ cursor.numDimensions() ];
+        double sum = 0;
+        long count = 0;
+        while ( cursor.hasNext() )
+        {
+            cursor.fwd();
+            cursor.localize( pos );
+            if ( outOfBounds( pos, intervalMin, intervalMax ) )
+                continue;
+            sum += cursor.get().getRealDouble();
+            count++;
+        }
+        return sum / (double) count;
+    }
+
+    private double median( final Cursor< ? extends RealType< ? > > cursor )
+    {
+        // FIXME
+        final long[] pos = new long[ cursor.numDimensions() ];
+        final List< Double > vals = new ArrayList<>();
+        while ( cursor.hasNext() )
+        {
+            cursor.fwd();
+            cursor.localize( pos );
+            if ( outOfBounds( pos, intervalMin, intervalMax ) )
+                continue;
+            vals.add( cursor.get().getRealDouble() );
+        }
+        // This is nearly twice as fast as SMILE's median implementation
+        return Util.median( vals.stream().mapToDouble( Double::doubleValue ).toArray() );
+    }
+
+    private double variance( final Cursor< ? extends RealType< ? > > cursor )
+    {
+        // FIXME
+        final long[] pos = new long[ cursor.numDimensions() ];
+        final List< Double > vals = new ArrayList<>();
+        while ( cursor.hasNext() )
+        {
+            cursor.fwd();
+            cursor.localize( pos );
+            if ( outOfBounds( pos, intervalMin, intervalMax ) )
+                continue;
+            vals.add( cursor.get().getRealDouble() );
+        }
+        return MathEx.var( vals.stream().mapToDouble( Double::doubleValue ).toArray() );
+    }
+
+    public static void main( String[] args )
+    {
+        ImageJ ij = new ImageJ();
+        ij.ui().showUI();
+        SNTService snt = new SNTService();
+        Tree t = snt.demoTree( "fractal" );
+        ImagePlus imp = snt.demoImage( "fractal" );
+        t.assignImage( imp );
+        Img< UnsignedByteType > img = ImageJFunctions.wrapReal( imp );
+        ProfileProcessor< UnsignedByteType > profiler = new ProfileProcessor<>( img, t.get( 0 ) );
+        profiler.setShape( Shape.CIRCLE );
+        profiler.setUseNodeRadii( false );
+        profiler.setRadius( 5 );
+        profiler.setMetric( Metric.VARIANCE );
+        long t0 = System.currentTimeMillis();
+        double[] values = profiler.call();
+        System.out.println( System.currentTimeMillis() - t0 );
+        ImgUtils.raiToImp( img, "Imp" ).show();
+        System.out.println( Arrays.toString( values ) );
+    }
+
+}

--- a/src/main/java/sc/fiji/snt/analysis/ProfileProcessor.java
+++ b/src/main/java/sc/fiji/snt/analysis/ProfileProcessor.java
@@ -61,8 +61,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
     private final long[] intervalMax;
     private Metric metric = Metric.SUM;
     private Shape shape = Shape.HYPERSPHERE;
-    private boolean useNodeRadii = true;
-    private int radius = 1;
+    private int radius = 0;
     private double[] values;
 
     public enum Metric {SUM, MIN, MAX, MEAN, MEDIAN, VARIANCE}
@@ -107,19 +106,10 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         this.shape = shape;
     }
 
-    /**
-     * Set whether or not to use the {@link PointInImage} radius (scaled in pixels) as the {@link Shape} radius.
-     *
-     * @param useNodeRadii
-     */
-    public void setUseNodeRadii( final boolean useNodeRadii )
-    {
-        this.useNodeRadii = useNodeRadii;
-    }
 
     /**
-     * Specify a fixed radius for each {@link Shape} region around each {@link PointInImage}. This setting
-     * is only used if setUseNodeRadii is false.
+     * Specify a fixed radius for each {@link Shape} region around each {@link PointInImage}. Set to <= 0 to use the
+     * actual {@link PointInImage} radii.
      *
      * @param radius
      */
@@ -162,7 +152,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         }
         for ( int i = 0; i < path.size(); ++i )
         {
-            long r = useNodeRadii ? Math.round( path.getNodeRadius( i ) / avgSep ) : radius;
+            long r = (radius <= 0) ? Math.round( path.getNodeRadius( i ) / avgSep ) : radius;
             if ( r < 1 )
                 r = 1;
 
@@ -394,13 +384,12 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         ImageJ ij = new ImageJ();
         ij.ui().showUI();
         SNTService snt = new SNTService();
-        Tree t = snt.demoTree( "fractal" );
-        ImagePlus imp = snt.demoImage( "fractal" );
+        Tree t = snt.demoTree( "OP_1" );
+        ImagePlus imp = snt.demoImage( "OP_1" );
         t.assignImage( imp );
         Img< UnsignedByteType > img = ImageJFunctions.wrapReal( imp );
         ProfileProcessor< UnsignedByteType > profiler = new ProfileProcessor<>( img, t.get( 0 ) );
         profiler.setShape( Shape.CIRCLE );
-        profiler.setUseNodeRadii( false );
         profiler.setRadius( 5 );
         profiler.setMetric( Metric.VARIANCE );
         long t0 = System.currentTimeMillis();

--- a/src/main/java/sc/fiji/snt/analysis/ProfileProcessor.java
+++ b/src/main/java/sc/fiji/snt/analysis/ProfileProcessor.java
@@ -294,7 +294,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         return false;
     }
 
-    private double sum( final Cursor< ? extends RealType< ? > > cursor )
+    private double sum( final Cursor< T > cursor )
     {
         final long[] pos = new long[ cursor.numDimensions() ];
         double sum = 0;
@@ -309,7 +309,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         return sum;
     }
 
-    private double min( final Cursor< ? extends RealType< ? > > cursor )
+    private double min( final Cursor< T > cursor )
     {
         final long[] pos = new long[ cursor.numDimensions() ];
         double min = Double.MAX_VALUE;
@@ -324,7 +324,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         return min;
     }
 
-    private double max( final Cursor< ? extends RealType< ? > > cursor )
+    private double max( final Cursor< T > cursor )
     {
         final long[] pos = new long[ cursor.numDimensions() ];
         double max = -Double.MAX_VALUE;
@@ -339,7 +339,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         return max;
     }
 
-    private double mean( final Cursor< ? extends RealType< ? > > cursor )
+    private double mean( final Cursor< T > cursor )
     {
         final long[] pos = new long[ cursor.numDimensions() ];
         double sum = 0;
@@ -356,7 +356,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         return sum / (double) count;
     }
 
-    private double median( final Cursor< ? extends RealType< ? > > cursor )
+    private double median( final Cursor< T > cursor )
     {
         // FIXME
         final long[] pos = new long[ cursor.numDimensions() ];
@@ -373,7 +373,7 @@ public class ProfileProcessor< T extends RealType< T > > implements Callable< do
         return Util.median( vals.stream().mapToDouble( Double::doubleValue ).toArray() );
     }
 
-    private double variance( final Cursor< ? extends RealType< ? > > cursor )
+    private double variance( final Cursor< T > cursor )
     {
         // FIXME
         final long[] pos = new long[ cursor.numDimensions() ];

--- a/src/main/java/sc/fiji/snt/util/CircleCursor3d.java
+++ b/src/main/java/sc/fiji/snt/util/CircleCursor3d.java
@@ -1,0 +1,309 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2021 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.util;
+
+import net.imglib2.*;
+import net.imglib2.util.LinAlgHelpers;
+
+/**
+ * Iterate the pixels of an oriented circle in 3-space using Bresenham's algorithm, where the
+ * circle is constructed from the unit normal to the circle plane, the center point, and radius. Alternatively,
+ * x and y basis vectors may be used in place of the circle normal.
+ *
+ * @author Cameron Arshadi
+ * @see net.imglib2.algorithm.region.CircleCursor
+ * @see <a href="https://en.wikipedia.org/wiki/Midpoint_circle_algorithm">Midpoint circle algorithm on Wikipedia.</a>
+ */
+public class CircleCursor3d< T > implements Cursor< T >
+{
+
+    protected final RandomAccessible< T > rai;
+    protected final RandomAccess< T > ra;
+    protected final Localizable centerPoint;
+    protected final double[] center;
+    protected final double[] xBasis;
+    protected final double[] yBasis;
+    // outermost radius
+    protected final long radius;
+    protected double[] xVec;
+    protected double[] yVec;
+    protected long[] longPos;
+    protected double[] doublePos;
+    // Dynamic parameters
+    protected long x;
+    protected long y;
+    protected boolean hasNext;
+    private long r;
+    private long err;
+    private Octant octant;
+
+    private enum Octant
+    {
+        O1, O2, O3, O4, O5, O6, O7, O8
+    }
+
+    /**
+     * Iterates over a Bresenham circle in the target {@link RandomAccessible}.
+     * Each point of the circle is iterated exactly once, and there is no "hole"
+     * in the circle.
+     *
+     * @param rai        the random accessible. It is the caller's responsibility to
+     *                   ensure it can be accessed everywhere the circle will be
+     *                   iterated.
+     * @param center     the circle center. Must be at least of dimension 3. Dimensions
+     *                   0, 1 and 2 are used to specify the circle center.
+     * @param radius     the circle radius.
+     * @param circleNorm the unit normal to the circle plane, must be 3-dimensional. The "new"
+     *                   x and y basis vectors will be constructed from this vector.
+     */
+    public CircleCursor3d( final RandomAccessible< T > rai, final Localizable center, final long radius,
+                           final double[] circleNorm )
+    {
+        this.rai = rai;
+        this.ra = rai.randomAccess();
+        this.centerPoint = center;
+        this.center = center.positionAsDoubleArray();
+        this.radius = radius;
+        this.xBasis = new double[ 3 ];
+        this.yBasis = new double[ 3 ];
+        final double epsilon = 1e-6;
+        // Took this hint from Mark's fitting code to handle the degenerate case
+        if ( Math.abs( circleNorm[ 0 ] ) < epsilon && Math.abs( circleNorm[ 1 ] ) < epsilon )
+        {
+            xBasis[ 0 ] = circleNorm[ 2 ];
+            xBasis[ 1 ] = 0;
+            xBasis[ 2 ] = -circleNorm[ 0 ];
+        }
+        else
+        {
+            xBasis[ 0 ] = -circleNorm[ 1 ];
+            xBasis[ 1 ] = circleNorm[ 0 ];
+            xBasis[ 2 ] = 0;
+        }
+        LinAlgHelpers.cross( circleNorm, xBasis, yBasis );
+        init();
+    }
+
+    /**
+     * Iterates over a Bresenham circle in the target {@link RandomAccessible}.
+     * Each point of the circle is iterated exactly once, and there is no "hole"
+     * in the circle.
+     *
+     * @param rai    the random accessible. It is the caller responsibility to
+     *               ensure it can be accessed everywhere the circle will be
+     *               iterated.
+     * @param center the circle center.
+     * @param radius the circle radius.
+     * @param xBasis the vector representing the "new" x-axis of the circle plane. Should be orthogonal to both the
+     *               circle normal and the yBasis
+     * @param yBasis the vector representing the "new" y-axis of the circle plane. Should be orthogonal to both the circle
+     *               normal and the xBasis
+     */
+    public CircleCursor3d( final RandomAccessible< T > rai, final Localizable center, final long radius,
+                           double[] xBasis, double[] yBasis )
+    {
+        this.rai = rai;
+        this.ra = rai.randomAccess();
+        this.centerPoint = center;
+        this.center = center.positionAsDoubleArray();
+        this.radius = radius;
+        this.xBasis = xBasis;
+        this.yBasis = yBasis;
+        init();
+    }
+
+    private void init()
+    {
+        this.doublePos = new double[ 3 ];
+        this.longPos = new long[ 3 ];
+        this.yVec = new double[ 3 ];
+        this.xVec = new double[ 3 ];
+        reset();
+    }
+
+    @Override
+    public Cursor< T > copyCursor()
+    {
+        return new CircleCursor3d<>( rai, centerPoint, radius, xBasis, yBasis );
+    }
+
+    @Override
+    public T next()
+    {
+        fwd();
+        return get();
+    }
+
+    @Override
+    public void jumpFwd( long steps )
+    {
+        for ( int i = 0; i < steps; i++ )
+            fwd();
+    }
+
+    @Override
+    public void fwd()
+    {
+        switch ( octant )
+        {
+            default:
+            case O1:
+                setPos( -x, y );
+                octant = Octant.O2;
+                break;
+
+            case O2:
+                setPos( -y, -x );
+                octant = Octant.O3;
+                break;
+
+            case O3:
+                setPos( x, -y );
+                octant = Octant.O4;
+                break;
+
+            case O4:
+                setPos( y, x );
+                r = err;
+                if ( r > x )
+                {
+                    x++;
+                    err += x * 2 + 1;
+                }
+                if ( r <= y )
+                {
+                    y++;
+                    err += y * 2 + 1;
+                }
+                if ( x >= 0 )
+                {
+                    hasNext = false;
+                }
+                octant = Octant.O1;
+                break;
+        }
+    }
+
+    protected void setPos( final long xScale, final long yScale )
+    {
+        LinAlgHelpers.scale( xBasis, xScale, xVec );
+        LinAlgHelpers.scale( yBasis, yScale, yVec );
+        LinAlgHelpers.add( center, xVec, doublePos );
+        LinAlgHelpers.add( doublePos, yVec, doublePos );
+        roundPos( doublePos, longPos );
+        ra.setPosition( longPos );
+    }
+
+    protected void roundPos( final double[] doublePos, final long[] longPos )
+    {
+        for ( int i = 0; i < doublePos.length; ++i )
+        {
+            longPos[ i ] = (long) Math.floor( doublePos[ i ] );
+        }
+    }
+
+    @Override
+    public void reset()
+    {
+        r = radius;
+        x = -radius;
+        y = 0;
+        err = 2 - 2 * radius;
+        octant = Octant.O1;
+        ra.setPosition( centerPoint );
+        hasNext = true;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return hasNext;
+    }
+
+    @Override
+    public void localize( final float[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public void localize( final double[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public void localize( final int[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public void localize( final long[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public int getIntPosition( final int d )
+    {
+        return ra.getIntPosition( d );
+    }
+
+    @Override
+    public long getLongPosition( int d )
+    {
+        return ra.getLongPosition( d );
+    }
+
+    @Override
+    public float getFloatPosition( final int d )
+    {
+        return ra.getFloatPosition( d );
+    }
+
+    @Override
+    public double getDoublePosition( final int d )
+    {
+        return ra.getDoublePosition( d );
+    }
+
+    @Override
+    public int numDimensions()
+    {
+        return ra.numDimensions();
+    }
+
+    @Override
+    public T get()
+    {
+        return ra.get();
+    }
+
+    @Override
+    public Sampler< T > copy()
+    {
+        return ra.copy();
+    }
+
+}

--- a/src/main/java/sc/fiji/snt/util/DiskCursor3d.java
+++ b/src/main/java/sc/fiji/snt/util/DiskCursor3d.java
@@ -1,0 +1,141 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2021 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.util;
+
+import net.imglib2.Cursor;
+import net.imglib2.Localizable;
+import net.imglib2.Point;
+import net.imglib2.RandomAccessible;
+import net.imglib2.util.LinAlgHelpers;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * Iterate the pixels of an oriented solid disk in 3-space, where the disk is constructed from the unit normal
+ * to the circle plane, the center point, and radius.
+ *
+ * @author Cameron Arshadi
+ */
+public class DiskCursor3d< T > extends CircleCursor3d< T >
+{
+
+    private List< Localizable > values;
+    private Iterator< Localizable > iterator;
+
+    /**
+     * Iterates over a parameterized disk in the target {@link RandomAccessible}.
+     * Each point of the disk is iterated exactly once.
+     *
+     * @param rai        the random accessible. It is the caller's responsibility to
+     *                   ensure it can be accessed everywhere the disk will be
+     *                   iterated.
+     * @param center     the disk center. Must be at least of dimension 3. Dimensions
+     *                   0, 1 and 2 are used to specify the disk center.
+     * @param radius     the circle radius.
+     * @param circleNorm the unit normal to the disk plane, must be 3-dimensional. The "new"
+     *                   x and y basis vectors will be constructed from this vector.
+     */
+    public DiskCursor3d( final RandomAccessible< T > rai, final Localizable center, final long radius,
+                         final double[] circleNorm )
+    {
+        super( rai, center, radius, circleNorm );
+        init();
+    }
+
+    /**
+     * Iterates over a parameterized disk in the target {@link RandomAccessible}.
+     * Each point of the disk is iterated exactly once.
+     *
+     * @param rai    the random accessible. It is the caller responsibility to
+     *               ensure it can be accessed everywhere the disk will be
+     *               iterated.
+     * @param center the disk center.
+     * @param radius the disk radius.
+     * @param xBasis the vector representing the "new" x-axis of the disk plane. Should be orthogonal to both the
+     *               circle normal and the yBasis
+     * @param yBasis the vector representing the "new" y-axis of the disk plane. Should be orthogonal to both the circle
+     *               normal and the xBasis
+     */
+    public DiskCursor3d( final RandomAccessible< T > rai, final Localizable center, final long radius,
+                         double[] xBasis, double[] yBasis )
+    {
+        super( rai, center, radius, xBasis, yBasis );
+        init();
+    }
+
+    private void init()
+    {
+        if ( values == null )
+        {
+            this.values = new ArrayList<>();
+            final double rr = radius * radius;
+            final double[] tmpY = new double[ 3 ];
+            final double[] tmpDiff = new double[ 3 ];
+            for ( long y = -radius; y <= radius; ++y )
+            {
+                LinAlgHelpers.scale( yBasis, y, yVec );
+                LinAlgHelpers.add( center, yVec, tmpY );
+                for ( long x = -radius; x <= radius; ++x )
+                {
+                    LinAlgHelpers.scale( xBasis, x, xVec );
+                    LinAlgHelpers.add( tmpY, xVec, doublePos );
+                    LinAlgHelpers.subtract( doublePos, center, tmpDiff );
+                    if ( LinAlgHelpers.squareLength( tmpDiff ) > rr )
+                        continue;
+                    roundPos( doublePos, longPos );
+                    values.add( new Point( longPos ) );
+                }
+            }
+        }
+        this.iterator = values.iterator();
+    }
+
+    @Override
+    public Cursor< T > copyCursor()
+    {
+        return new DiskCursor3d<>( rai, centerPoint, radius, xBasis, yBasis );
+    }
+
+    @Override
+    public void fwd()
+    {
+        ra.setPosition( iterator.next() );
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return iterator.hasNext();
+    }
+
+    @Override
+    public void reset()
+    {
+        if ( values != null )
+            iterator = values.iterator();
+
+    }
+
+}

--- a/src/main/java/sc/fiji/snt/util/PathCursor.java
+++ b/src/main/java/sc/fiji/snt/util/PathCursor.java
@@ -1,0 +1,170 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2021 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.util;
+
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.Sampler;
+import sc.fiji.snt.Path;
+
+/**
+ * Iterate over the pixels along the defined nodes of a {@link Path}
+ *
+ * @author Cameron Arshadi
+ */
+public class PathCursor< T > implements Cursor< T >
+{
+
+    private final RandomAccessible< T > rai;
+    private final Path path;
+    private final RandomAccess< T > ra;
+    private int i;
+    private boolean hasNext;
+
+    public PathCursor( final RandomAccessible< T > accessible, final Path path )
+    {
+        this.rai = accessible;
+        this.ra = accessible.randomAccess();
+        if ( path.size() == 0 )
+            throw new IllegalArgumentException( "Path cannot be empty" );
+        this.path = path;
+        reset();
+    }
+
+    @Override
+    public Cursor< T > copyCursor()
+    {
+        return new PathCursor<>( rai, path );
+    }
+
+    @Override
+    public T next()
+    {
+        fwd();
+        return get();
+    }
+
+    @Override
+    public void jumpFwd( long steps )
+    {
+        for ( int s = 0; s < steps; s++ )
+            fwd();
+    }
+
+    @Override
+    public void fwd()
+    {
+        final int x = path.getXUnscaled( i );
+        final int y = path.getYUnscaled( i );
+        ra.setPosition( x, 0 );
+        ra.setPosition( y, 1 );
+        if ( ra.numDimensions() == 3 )
+        {
+            int z = path.getZUnscaled( i );
+            ra.setPosition( z, 2 );
+        }
+        if ( ++i >= path.size() )
+            hasNext = false;
+    }
+
+    @Override
+    public void reset()
+    {
+        i = 0;
+        hasNext = true;
+    }
+
+    @Override
+    public boolean hasNext()
+    {
+        return hasNext;
+    }
+
+    @Override
+    public void localize( final float[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public void localize( final double[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public void localize( final int[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public void localize( final long[] position )
+    {
+        ra.localize( position );
+    }
+
+    @Override
+    public int getIntPosition( final int d )
+    {
+        return ra.getIntPosition( d );
+    }
+
+    @Override
+    public long getLongPosition( int d )
+    {
+        return ra.getLongPosition( d );
+    }
+
+    @Override
+    public float getFloatPosition( final int d )
+    {
+        return ra.getFloatPosition( d );
+    }
+
+    @Override
+    public double getDoublePosition( final int d )
+    {
+        return ra.getDoublePosition( d );
+    }
+
+    @Override
+    public int numDimensions()
+    {
+        return ra.numDimensions();
+    }
+
+    @Override
+    public T get()
+    {
+        return ra.get();
+    }
+
+    @Override
+    public Sampler< T > copy()
+    {
+        return ra.copy();
+    }
+
+}

--- a/src/main/resources/script_templates/Neuroanatomy/Analysis/Draw_Disks_Demo.groovy
+++ b/src/main/resources/script_templates/Neuroanatomy/Analysis/Draw_Disks_Demo.groovy
@@ -1,0 +1,79 @@
+#@ SNTService snt
+
+/**
+ * file: Draw_Disks_Demo.groovy
+ * author: Cameron Arshadi
+ * version: 20210913	
+ * info: A demo which illustrates iteration over SNT's custom cursors by drawing oriented
+ *       disks in 3D along an axon.
+ */
+
+import net.imglib2.Point;
+import net.imglib2.util.LinAlgHelpers;
+import net.imglib2.algorithm.region.hypersphere.HyperSphere;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import sc.fiji.snt.*
+import sc.fiji.snt.analysis.*
+import sc.fiji.snt.analysis.graph.*
+import sc.fiji.snt.analysis.sholl.*
+import sc.fiji.snt.annotation.*
+import sc.fiji.snt.io.*
+import sc.fiji.snt.plugin.*
+import sc.fiji.snt.util.*
+import sc.fiji.snt.viewer.*
+import ij3d.Image3DUniverse;
+import org.scijava.vecmath.Color3f;
+
+// Documentation Resources: https://imagej.net/SNT:_Scripting
+// Latest SNT API: https://morphonets.github.io/SNT/
+
+def drawDisks(path, img, min, max) 
+{
+	pos = new long[img.numDimensions()]
+	tangent = new double[3]
+	for (i=0; i<path.size(); i++)
+	{
+		path.getTangent(i, 1, tangent)
+		// check if the two points are in the same location, skipping if so
+		if (Arrays.stream(tangent).allMatch(e -> e == 0))
+			continue
+		LinAlgHelpers.normalize(tangent)
+		point = new Point(path.getXUnscaled(i), path.getYUnscaled(i), path.getZUnscaled(i))
+		cursor = new DiskCursor3d(img, point, 10, tangent)
+		while (cursor.hasNext()) 
+		{
+			cursor.fwd()
+			cursor.localize(pos)
+			// Don't attempt to access out-of-bounds points (it will throw an ArrayIndexOutOfBoundsException)
+			if (outOfBounds(pos, min, max))
+				continue
+			cursor.get().set(255)
+		}
+	}
+}
+
+def outOfBounds(pos, min, max) 
+{
+	for (d=0; d<pos.length; d++)
+		if (pos[d] < min[d] || pos[d] > max[d])
+			return true;
+	return false;
+}
+
+def main() 
+{
+	imp = snt.demoImage("OP")
+	img = ImageJFunctions.wrapReal(imp)
+	min = img.minAsLongArray()
+	max = img.maxAsLongArray()
+	tree = snt.demoTree("OP")
+	tree.assignImage(imp)
+	path = tree.get(0)
+	path.downsample(0.6)
+	drawDisks(path, img, min, max)
+	Image3DUniverse univ = new Image3DUniverse();
+	univ.show();
+	univ.addVoltex(imp, new Color3f(0,255,0), "OP_1", 25, new boolean[] {true, true, true}, 1);
+}
+
+main();

--- a/src/test/java/sc/fiji/snt/util/CircleCursor3dTest.java
+++ b/src/test/java/sc/fiji/snt/util/CircleCursor3dTest.java
@@ -1,0 +1,97 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2021 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.util;
+
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.algorithm.region.CircleCursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Cameron Arshadi
+ */
+public class CircleCursor3dTest
+{
+
+    @Test
+    public void test() throws InterruptedException
+    {
+        Img< UnsignedByteType > rai = ArrayImgs.unsignedBytes( 128, 128, 1 );
+        Point center = new Point( 64, 64, 0 );
+        long radius = 40;
+        Cursor< UnsignedByteType > testCursor = new CircleCursor3d<>(
+                rai,
+                center,
+                radius,
+                new double[]{ 1, 0, 0 },
+                new double[]{ 0, 1, 0 } );
+        int testCount = 0;
+        while ( testCursor.hasNext() )
+        {
+            testCursor.fwd();
+            UnsignedByteType t = testCursor.get();
+            t.set( t.getInteger() + 25 );
+            testCount++;
+        }
+
+        CircleCursor< UnsignedByteType > expectedCursor = new CircleCursor<>(
+                rai,
+                center,
+                radius );
+        int expectedCount = 0;
+        while ( expectedCursor.hasNext() )
+        {
+            expectedCursor.fwd();
+            UnsignedByteType t = expectedCursor.get();
+            t.set( t.getInteger() + 25 );
+            expectedCount++;
+        }
+
+        assertEquals( expectedCount, testCount );
+
+        Cursor< UnsignedByteType > resultCursor = rai.cursor();
+        int count = 0;
+        while ( resultCursor.hasNext() )
+        {
+            int t = resultCursor.next().get();
+            if ( t == 50 )
+            {
+                ++count;
+            }
+            else
+            {
+                assert t == 0;
+            }
+        }
+        assertEquals( expectedCount, count );
+//        ImageJFunctions.show( rai );
+//        Thread.sleep( 10000 );
+
+    }
+
+}

--- a/src/test/java/sc/fiji/snt/util/DiskCursor3dTest.java
+++ b/src/test/java/sc/fiji/snt/util/DiskCursor3dTest.java
@@ -1,0 +1,97 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2021 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.util;
+
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.algorithm.region.hypersphere.HyperSphere;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Cameron Arshadi
+ */
+public class DiskCursor3dTest
+{
+
+    @Test
+    public void test() throws InterruptedException
+    {
+        Img< UnsignedByteType > rai = ArrayImgs.unsignedBytes( 128, 128, 1 );
+        Point center = new Point( 64, 64, 0 );
+        long radius = 40;
+        Cursor< UnsignedByteType > testCursor = new DiskCursor3d<>(
+                rai,
+                center,
+                radius,
+                new double[]{ 1, 0, 0 },
+                new double[]{ 0, 1, 0 } );
+        int testCount = 0;
+        while ( testCursor.hasNext() )
+        {
+            testCursor.fwd();
+            UnsignedByteType t = testCursor.get();
+            t.set( t.getInteger() + 25 );
+            testCount++;
+        }
+
+        Cursor< UnsignedByteType > expectedCursor = new HyperSphere<>(
+                Views.dropSingletonDimensions( rai ),
+                new Point( 64, 64 ),
+                radius ).cursor();
+        int expectedCount = 0;
+        while ( expectedCursor.hasNext() )
+        {
+            expectedCursor.fwd();
+            UnsignedByteType t = expectedCursor.get();
+            t.set( t.getInteger() + 25 );
+            expectedCount++;
+        }
+
+        assertEquals( expectedCount, testCount );
+
+        Cursor< UnsignedByteType > resultCursor = rai.cursor();
+        int count = 0;
+        while ( resultCursor.hasNext() )
+        {
+            int t = resultCursor.next().get();
+            if ( t == 50 )
+            {
+                ++count;
+            }
+            else
+            {
+                assert t == 0;
+            }
+        }
+        assertEquals( expectedCount, count );
+//        ImageJFunctions.show( rai );
+//        Thread.sleep( 10000 );
+    }
+
+}

--- a/src/test/java/sc/fiji/snt/util/PathCursorTest.java
+++ b/src/test/java/sc/fiji/snt/util/PathCursorTest.java
@@ -1,0 +1,75 @@
+/*-
+ * #%L
+ * Fiji distribution of ImageJ for the life sciences.
+ * %%
+ * Copyright (C) 2010 - 2021 Fiji developers.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+package sc.fiji.snt.util;
+
+import ij.ImagePlus;
+import net.imglib2.Cursor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.junit.Before;
+import org.junit.Test;
+import sc.fiji.snt.Path;
+import sc.fiji.snt.SNTService;
+import sc.fiji.snt.Tree;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Cameron Arshadi
+ */
+public class PathCursorTest
+{
+
+    private Path path;
+    private RandomAccessibleInterval< UnsignedByteType > img;
+
+    @Before
+    public void setup()
+    {
+        SNTService snt = new SNTService();
+        Tree tree = snt.demoTree( "OP" );
+        path = tree.get( 0 );
+        ImagePlus imp = snt.demoImage( "OP" );
+        img = ImageJFunctions.wrap( imp );
+    }
+
+    @Test
+    public void test()
+    {
+        Cursor< UnsignedByteType > cursor = new PathCursor<>( img, path );
+        int i = 0;
+        final int[] pos = new int[ 3 ];
+        while ( cursor.hasNext() )
+        {
+            cursor.next();
+            cursor.localize( pos );
+            assertEquals( path.getXUnscaled( i ), pos[ 0 ] );
+            assertEquals( path.getYUnscaled( i ), pos[ 1 ] );
+            assertEquals( path.getZUnscaled( i ), pos[ 2 ] );
+            i++;
+        }
+        assertEquals( path.size(), i );
+    }
+
+}


### PR DESCRIPTION
This PR adds a new set of functionality for profiling and iterating over local neighborhoods around Path points.
We have had several requests for this type of analysis, see [1](https://forum.image.sc/t/snt-export-intensity-profile-xyz-coordinates/57156) and [2](https://forum.image.sc/t/intensity-profile-along-a-tubular-structure/57196)

Three new imglib2-style `Cursor<T>` types are proposed:
1) `CircleCursor3d` - Iterates over an oriented 2D circle in 3-space, can be thought of as a basis-agnostic version of [CircleCursor](https://github.com/imglib/imglib2-algorithm/blob/master/src/main/java/net/imglib2/algorithm/region/CircleCursor.java).  The circle plane may be specified either with the unit normal or with two orthogonal basis vectors.
2) `DiskCursor3d` - Iterates over an oriented 2D disk in 3-space, i.e., a solid version of `CircleCursor3d`. Like above, the disk plane may be specified either with the unit normal or with two orthogonal basis vectors.
3) `PathCursor` - Iterates the nodes of a Path in 2+D

Here is an example of some circles produced by `CircleCursor3d` (Note the disks appear stretched due to aniostropic voxel spacing in the rendering )

![circles](https://user-images.githubusercontent.com/44130022/133167850-6bc51d30-36e1-477b-a2bf-a3ba5454269f.png)

and for `DiskCursor3d`

![disks3d](https://user-images.githubusercontent.com/44130022/133167863-c40b64e9-ca33-4c4d-bfa4-4f943ada9a32.png)


if you want to use `CircleCursor3d` and `DiskCursor3d` on 2D images, you should specify the proper basis (or not), e.g.,
```java
Cursor<T> cursor = new CircleCursor3d<>(rai, center, radius, new double[]{1,0,0}, new double[]{0,1,0})
```
these then become equivalent to [CircleCursor](https://github.com/imglib/imglib2-algorithm/blob/master/src/main/java/net/imglib2/algorithm/region/CircleCursor.java) and [HyperSphereCursor](https://github.com/imglib/imglib2-algorithm/blob/master/src/main/java/net/imglib2/algorithm/region/hypersphere/HyperSphereCursor.java), respectively.

![image](https://user-images.githubusercontent.com/44130022/133172181-5c91e320-25fa-4a94-9f7d-9044410e2353.png)
![disks2d](https://user-images.githubusercontent.com/44130022/133167901-348cad2b-4500-47d9-a2de-f3f6fcbd0066.png)


Additionally, this PR adds a new `ProfileProcessor` class which uses these cursors (and others) to profile and compute statistics for the local neighborhood around `Path` points. The following metrics are currently available:
1) sum
2) min
3) max
4) mean
5) median
6) variance

example usage
```groovy
profiler = new ProfileProcessor(img, path)
profiler.setMetric(ProfileProcessor.Metric.SUM)
profiler.setShape(ProfileProcessor.Shape.DISK)
// radius in pixels (int), sets a global radius for all nodes. set to <= 0 to use actual PointInImage radius
profiler.setRadius(1) 
vals = profiler.call()
```
where the returned `vals` is a `double[]` representing the computed metric at each Path node.

Note that this PR only adds the above functionality, and does not link it with the current plotting
functionality of `PathProfiler`.

Also, adds a demo script  - `Draw_Disks_Demo.groovy` - showing how to use the cursors
