### PR TITLE
Fix SWC export from File menu when file paths have multiple '.' separators

### DIFF
--- a/src/main/java/sc/fiji/snt/SNTUI.java
+++ b/src/main/java/sc/fiji/snt/SNTUI.java
@@ -4028,7 +4028,7 @@ public class SNTUI extends JDialog {
 				return false;
 		}
 		SNTUtils.log("Exporting paths... " + prefix);
-		final boolean success = pathAndFillManager.exportAllPathsAsSWC(primaryPaths, prefix);
+		final boolean success = pathAndFillManager.exportAllPathsAsSWC(primaryPaths, filePath);
 		plugin.unsavedPaths = !success;
 		return success;
 	}


### PR DESCRIPTION
Closes #97 