### PR TITLE
Fix OBJMesh.setTransparency

### DIFF
--- a/src/main/java/sc/fiji/snt/viewer/OBJMesh.java
+++ b/src/main/java/sc/fiji/snt/viewer/OBJMesh.java
@@ -188,7 +188,7 @@ public class OBJMesh {
 	public void setTransparency(final double transparencyPercent) {
 		final Color existing = drawable.getColor();
 		final Color adjusted = new Color(existing.r, existing.g, existing.b,
-				(int) Math.round((100 - transparencyPercent) * 255 / 100));
+				(float) (1 - (transparencyPercent / 100.0)));
 		drawable.setColor(adjusted);
 	}
 


### PR DESCRIPTION
`mesh.setTransparency(95.0) `

(note the png preview colors look weird)

before
![Basal_Ganglia_sagittal](https://user-images.githubusercontent.com/44130022/173164710-b8eaf79f-bcf0-477f-a2d8-505a8d72f771.png)

after
![Basal_Ganglia_sagittal](https://user-images.githubusercontent.com/44130022/173164691-88bf663c-01f2-41ea-a37a-8c8ee7c061bd.png)

