### PR TITLE
PathManagerUI: don't change slice on Path selection

### DIFF
--- a/src/main/java/sc/fiji/snt/PathManagerUI.java
+++ b/src/main/java/sc/fiji/snt/PathManagerUI.java
@@ -847,7 +847,8 @@ public class PathManagerUI extends JDialog implements PathAndFillListener,
 
 	private void updateHyperstackPosition(final Path p) {
 		final ImagePlus imp = plugin.getImagePlus();
-		if (imp != null) imp.setPosition(p.getChannel(), p.getZUnscaled(0) + 1, p.getFrame()); // 1-based indices
+		// Keep slice where it is for tracing ergonomics
+		if (imp != null) imp.setPosition(p.getChannel(), imp.getSlice(), p.getFrame()); // 1-based indices
 	}
 
 	private void displayTmpMsg(final String msg) {


### PR DESCRIPTION
Currently, selecting a `Path` changes the canvas slice position to the first node on the `Path`.
This is an ergonomic impediment in almost all typical tracing workflows (that I have tried at least).

Cases 1 and 2 apply primarily to tracing axon, which necessitates a different workflow compared to tracing dendrite.

Case 1: User traces hierarchically, starting with the backbone and adding higher order branches as forks. 
Paths are from `root -> terminal` or `branch -> terminal` in this case, not `branch -> branch`

<img width="423" alt="case2" src="https://user-images.githubusercontent.com/44130022/173693570-ed86a4b4-a101-4951-9169-bebb094e38d7.png">

After finishing a Path, you want to be able to create a fork somewhere along that Path, usually towards the middle/end of the segment. However,  when the slice position updates where the first node is, you lose your orientation since this is likely outside your field of view. The user then has to scroll all the way back (potentially through hundreds of slices) to where they were, which is both time consuming and taxing on the wrist.

Case 2: User traces hierarchically, but every branch is created as a separate Path
<img width="423" alt="case1" src="https://user-images.githubusercontent.com/44130022/173693553-695445d8-be23-4aba-8bfe-aafdf24d6885.png">
Similar situation to the above, but this time the user will always create forks at the end of the Path, so having the slice jump to the start throws them off

Case 3: Tracing dendrites, user creates a single "soma" point and traces multiple basal dendrites out of that point
<img width="513" alt="case3" src="https://user-images.githubusercontent.com/44130022/173693588-3be4ed03-82c5-4994-8af1-6736e7370619.png">

This is the only case where I think the original behavior somewhat makes sense, since each basal dendrite is usually traced as an outward connection from the "root" or soma point(s). However, the user still has to trace out higher order branches, which generally takes the bulk of tracing time (for more complex cells at least), going back to cases 1 and 2.

I think we shouldn't change the slice position, so the user always knows where they are in Z and can navigate/place forks quickly.

