### PR TITLE
Make AllenCompartment: Make isChild() isParent() methods more robust

### DIFF
--- a/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
+++ b/src/main/java/sc/fiji/snt/annotation/AllenCompartment.java
@@ -177,7 +177,7 @@ public class AllenCompartment implements BrainAnnotation {
 		final int parentIdxInPath = childStructureIdPath.lastIndexOf("/" + parentIdString + "/");
 		if (parentIdxInPath == -1)
 			return false;
-		return Arrays.stream(childStructureIdPath.substring(parentIdxInPath + parentIdString.length()).split("/"))
+		return Arrays.stream(childStructureIdPath.substring(parentIdxInPath + parentIdString.length() + 1).split("/"))
 				.filter(s -> !s.isEmpty())
 				.map(Integer::parseInt)
 				.anyMatch(id -> id == id());


### PR DESCRIPTION
@carshadi , could you please have a look at this?

I noticed some really weird results of AllenCompartment#isChildOf() #isParentOf() even after your improvements with https://github.com/morphonets/SNT/pull/119, I am looking into them now (these were json files converted adhoc from SWCs [maybe something went awry there])

I _think_ a problem could arise with the methods treating the full structure ID path, rather than just the upstream list (when looking for parents) or downstream (when looking for children) of the actual compartment. Could you please have a look? Or maybe you have some better ideas on how to make this fool-proof?
