### PR TITLE
Fix DirectedWeightedGraph.getTree when tree is null

### DIFF
--- a/src/main/java/sc/fiji/snt/analysis/graph/DirectedWeightedGraph.java
+++ b/src/main/java/sc/fiji/snt/analysis/graph/DirectedWeightedGraph.java
@@ -615,7 +615,8 @@ public class DirectedWeightedGraph extends SNTGraph<SWCPoint, SWCWeightedEdge> {
 	public Tree getTree(final boolean createNewTree) {
 		if (createNewTree) {
 			updateVertexProperties();
-			return new Tree(this, tree.getLabel());
+			final String label = tree != null ? tree.getLabel() : "";
+			return new Tree(this, label);
 		} else {
 			return tree;
 		}


### PR DESCRIPTION
This happens when you create a DirectedWeightedGraph from a set of points instead of a tree